### PR TITLE
Removes the need for caseWrap in verifier

### DIFF
--- a/rewritev/Main.hs
+++ b/rewritev/Main.hs
@@ -66,17 +66,18 @@ runWithArgs as = do
   let rule' = case rule of
               Just r -> r
               Nothing -> error "not found"
-  let (rewrite_state_r, bindings_r) = initWithRHS init_state bindings $ rule'
+  res <- checkRule config init_state bindings rule'
+  -- let (rewrite_state_r, bindings_r) = initWithRHS init_state bindings $ rule'
   
-  let (rewrite_state_l, bindings_l) = initWithLHS init_state bindings $ rule'
+  -- let (rewrite_state_l, bindings_l) = initWithLHS init_state bindings $ rule'
 
-  let pairs_l = symbolic_ids rewrite_state_l
-      pairs_r = symbolic_ids rewrite_state_r
+  -- let pairs_l = symbolic_ids rewrite_state_l
+  --     pairs_r = symbolic_ids rewrite_state_r
 
-  S.SomeSolver solver <- initSolver config
-  res <- verifyLoop solver (zip pairs_l pairs_r)
-         [(rewrite_state_l, rewrite_state_r)]
-         bindings_l bindings_r config
+  -- S.SomeSolver solver <- initSolver config
+  -- res <- verifyLoop solver (zip pairs_l pairs_r)
+  --        [(rewrite_state_l, rewrite_state_r)]
+  --        bindings_l bindings_r config
   print res
   return ()
 

--- a/src/G2/Equiv/EquivADT.hs
+++ b/src/G2/Equiv/EquivADT.hs
@@ -81,7 +81,12 @@ moreRestrictive s@(State {expr_env = h}) hm e1 e2 =
     (App f1 a1, App f2 a2) | Just hm_f <- moreRestrictive s hm f1 f2
                            , Just hm_a <- moreRestrictive s hm_f a1 a2 -> Just hm_a
                            | otherwise -> Nothing
-    (Data d1, Data d2) | d1 == d2 -> Just hm
+    -- We just compare the names of the DataCons, not the types of the DataCons.
+    -- This is because (1) if two DataCons share the same name, they must share the
+    -- same type, but (2) "the same type" may be represented in different syntactic
+    -- ways, most significantly bound variable names may differ
+    -- "forall a . a" is the same type as "forall b . b", but fails a syntactic check.
+    (Data (DataCon d1 _), Data (DataCon d2 _)) | d1 == d2 -> Just hm
                        | otherwise -> Nothing
     -- TODO potential problems with type equality checking?
     (Prim p1 t1, Prim p2 t2) | p1 == p2
@@ -195,15 +200,19 @@ exprPairing s1@(State {expr_env = h1}) s2@(State {expr_env = h2}) e1 e2 pairs =
     (_, Var i) | E.isSymbolic (idName i) h2 -> Just (HS.insert (e1, e2) pairs)
                | Just e <- E.lookup (idName i) h2 -> exprPairing s1 s2 e1 e pairs
                | otherwise -> error "unmapped variable"
-    (App _ _, App _ _) | (Data d1):l1 <- unApp e1
-                       , (Data d2):l2 <- unApp e2
-                       , d1 == d2 -> let ep = uncurry (exprPairing s1 s2)
-                                         ep' hs p = ep p hs
-                                         l = zip l1 l2
-                                     in foldM ep' pairs l
+    -- See note in `moreRestrictive` regarding comparing DataCons
+    (App _ _, App _ _) | (Data (DataCon d1 _)):l1 <- unApp e1
+                       , (Data (DataCon d2 _)):l2 <- unApp e2 ->
+        if d1 == d2 then
+            let ep = uncurry (exprPairing s1 s2)
+                ep' hs p = ep p hs
+                l = zip l1 l2
+            in foldM ep' pairs l
+            else Nothing
     (App _ _, _) -> Just (HS.insert (e1, e2) pairs)
     (_, App _ _) -> Just (HS.insert (e1, e2) pairs)
-    (Data d1, Data d2) | d1 == d2 -> Just pairs
+    (Data (DataCon d1 _), Data (DataCon d2 _))
+                       | d1 == d2 -> Just pairs
                        | otherwise -> Nothing
     (Prim _ _, _) -> Just (HS.insert (e1, e2) pairs)
     (_, Prim _ _) -> Just (HS.insert (e1, e2) pairs)

--- a/src/G2/Equiv/Verifier.hs
+++ b/src/G2/Equiv/Verifier.hs
@@ -144,7 +144,7 @@ verifyLoop' solver s1 s2 orig assumption_set = do
       ready_hs = HS.fromList ready
   res <- checkObligations solver s1 s2 assumption_set ready_hs
   let currExprWrap e = CurrExpr Evaluate e
-      currExprInsert s e = s { curr_expr = currExprWrap (caseWrap e) }
+      currExprInsert s e = s { curr_expr = currExprWrap e }
   case res of
       S.UNSAT () -> return $ Just [(currExprInsert s1 e1, currExprInsert s2 e2) | (e1, e2) <- not_ready]
       _ -> return Nothing
@@ -213,11 +213,6 @@ obligationWrap obligations =
     if null eq_list
     then Nothing
     else Just $ ExtCond (App (Prim Not TyUnknown) conj) True
-
-caseWrap :: Expr -> Expr
-caseWrap e =
-  let matchId = Id (Name "caseWrap" Nothing 0 Nothing) (typeOf e) in
-  Case e matchId [Alt Default (Var matchId)]
 
 checkRule :: Config ->
              State t ->

--- a/src/G2/Equiv/Verifier.hs
+++ b/src/G2/Equiv/Verifier.hs
@@ -318,8 +318,14 @@ moreRestrictive s@(State {expr_env = h}) hm e1 e2 =
     (App f1 a1, App f2 a2) | Just hm_f <- moreRestrictive s hm f1 f2
                            , Just hm_a <- moreRestrictive s hm_f a1 a2 -> Just hm_a
                            | otherwise -> Nothing
-    (Data d1, Data d2) | d1 == d2 -> Just hm
-                       | otherwise -> Nothing
+    -- We just compare the names of the DataCons, not the types of the DataCons.
+    -- This is because (1) if two DataCons share the same name, they must share the
+    -- same type, but (2) "the same type" may be represented in different syntactic
+    -- ways, most significantly bound variable names may differ
+    -- "forall a . a" is the same type as "forall b . b", but fails a syntactic check.
+    (Data (DataCon d1 _), Data (DataCon d2 _))
+                                  | d1 == d2 -> Just hm
+                                  | otherwise -> Nothing
     -- TODO potential problems with type equality checking?
     (Prim p1 t1, Prim p2 t2) | p1 == p2
                              , t1 == t2 -> Just hm

--- a/src/G2/Execution/Reducer.hs
+++ b/src/G2/Execution/Reducer.hs
@@ -25,6 +25,7 @@ module G2.Execution.Reducer ( Reducer (..)
                             -- Reducers
                             , RCombiner (..)
                             , StdRed (..)
+                            , ConcSymReducer (..)
                             , NonRedPCRed (..)
                             , TaggerRed (..)
                             , Logger (..)
@@ -76,6 +77,7 @@ import qualified G2.Language.ExprEnv as E
 import G2.Execution.Rules
 import G2.Language
 import qualified G2.Language.Monad as MD
+import qualified G2.Language.PathConds as PC
 import qualified G2.Language.Stack as Stck
 import G2.Solver
 import G2.Lib.Printers
@@ -346,6 +348,94 @@ instance (Solver solver, Simplifier simplifier) => Reducer (StdRed solver simpli
         (r, s', b') <- stdReduce share solver simplifier s b
         
         return (if r == RuleIdentity then Finished else InProgress, s', b', stdr)
+
+data ConcSymReducer = ConcSymReducer
+
+-- Forces a lone symbolic variable with a type corresponding to an ADT
+-- to evaluate to some value of that ADT
+instance Reducer ConcSymReducer () t where
+    initReducer _ _ = ()
+
+    redRules red _ s@(State { curr_expr = CurrExpr _ (Var i@(Id n t))
+                            , expr_env = eenv
+                            , type_env = tenv
+                            , path_conds = pc
+                            , symbolic_ids = sid })
+                   b@(Bindings { name_gen = ng })
+        | E.isSymbolic n eenv
+        , Just (e, pc', sid', ng') <- arbDCCase tenv ng t= do
+            let 
+                s' = s { curr_expr = CurrExpr Return e
+                       , expr_env =
+                            foldr (\i -> E.insertSymbolic (idName i) i)
+                                  (E.insert n e eenv)
+                                  sid'
+                       , path_conds = foldr PC.insert pc pc'
+                       , symbolic_ids = sid' ++ L.delete i sid } 
+                b' =  b { name_gen = ng' }
+            return (InProgress, [(s', ())], b', red)
+    redRules red _ s b = return (NoProgress, [(s, ())], b, red)
+
+-- | Build a case expression with one alt for each data constructor of the given type
+-- and symbolic arguments.  Thus, the case expression could evaluate to any value of the
+-- given type.
+arbDCCase :: TypeEnv
+          -> NameGen
+          -> Type
+          -> Maybe (Expr, [PathCond], [Id], NameGen)
+arbDCCase tenv ng t
+    | TyCon tn _:ts <- unTyApp t
+    , Just adt <- M.lookup tn tenv =
+        let
+            dcs = dataCon adt
+            (bindee_id, ng') = freshId TyLitInt ng
+
+            bound = boundIds adt
+            bound_ts = zip bound ts
+
+            ty_apped_dcs = map (\dc -> mkApp $ Data dc:map Type ts) dcs
+            ((ng'', symbs), apped_dcs) =
+                        L.mapAccumL
+                            (\(ng_, symbs_) dc ->
+                                let
+                                    anon_ts = anonArgumentTypes dc
+                                    re_anon = foldr (\(i, t) -> retype i t) anon_ts bound_ts
+                                    (ars, ng_') = freshIds re_anon ng_
+                                    symbs_' = symbs_ ++ ars
+                                in
+                                ((ng_', symbs_'), mkApp $ dc:map Var ars)
+                            )
+                            (ng', [])
+                            ty_apped_dcs
+
+            bindee = Var bindee_id
+
+            pc = mkBounds bindee 1 (toInteger $ length dcs)
+
+            e = createCaseExpr bindee_id apped_dcs
+        in
+        Just (e, pc, bindee_id:symbs, ng'')
+    | otherwise = Nothing
+
+createCaseExpr :: Id -> [Expr] -> Expr
+createCaseExpr _ [e] = e
+createCaseExpr newId es@(_:_) =
+    let
+        -- We assume that PathCond restricting newId's range is added elsewhere
+        (_, alts) = bindExprToNum (\num e -> Alt (LitAlt (LitInt num)) e) es
+    in Case (Var newId) newId alts
+createCaseExpr _ [] = error "No exprs"
+
+bindExprToNum :: (Integer -> a -> b) -> [a] -> (Integer, [b])
+bindExprToNum f es = L.mapAccumL (\num e -> (num + 1, f num e)) 1 es
+
+mkBounds :: Expr -> Integer -> Integer -> [PathCond]
+mkBounds e l u =
+    let
+        t = TyFun TyLitInt $ TyFun TyLitInt TyLitInt
+    in
+    [ ExtCond (App (App (Prim Le t) (Lit (LitInt l))) e) True
+    , ExtCond (App (App (Prim Le t) e) (Lit (LitInt u))) True]
 
 -- | Removes and reduces the values in a State's non_red_path_conds field. 
 data NonRedPCRed = NonRedPCRed

--- a/src/G2/Interface/Interface.hs
+++ b/src/G2/Interface/Interface.hs
@@ -416,7 +416,10 @@ runG2ForRewriteV state config bindings = do
 
     (in_out, bindings') <- case initRedHaltOrd solver simplifier config of
                 (red, hal, ord) ->
-                    runG2WithSomes red hal ord solver simplifier sym_config state bindings
+                    let
+                        red' = red <~ SomeReducer ConcSymReducer
+                    in
+                    runG2WithSomes red' hal ord solver simplifier sym_config state bindings
 
     close solver
 

--- a/tests/RewriteVerify/Correct/SimpleCorrect.hs
+++ b/tests/RewriteVerify/Correct/SimpleCorrect.hs
@@ -22,5 +22,5 @@ just n = Just n
 "maybeForceZero" maybeForce Nothing = 0
 "maxWithSelf" forall x . maxOfInt x x = x
 "addOneJust" forall n . just (addOne n) = Just (1 + n)
-"justJust" forall n . just n = Just n
+"justJust" forall (n :: Int) . just n = Just n
   #-}

--- a/tests/RewriteVerify/Incorrect/SimpleIncorrect.hs
+++ b/tests/RewriteVerify/Incorrect/SimpleIncorrect.hs
@@ -16,10 +16,14 @@ maxOfInt x y = if x < y then y else x
 just :: t -> Maybe t
 just n = Just n
 
+idTuple :: (Int, Int) -> (Int, Int)
+idTuple x = x
+
 {-# RULES
 "badMaybeForce" forall x . maybeForce (Just x) = if x == x then maybeForce Nothing else x
 "badNegation" forall a . negation a = negation $ negation a
 "badMax" forall x y . maxOfInt x y = if x == y then y else x
 "badMaxLeft" forall x y . maxOfInt x y = x
 "badJust" forall n . just n = Nothing
+"badTuple" forall n . idTuple n = (0, 0)
   #-}

--- a/tests/RewriteVerify/RewriteVerifyTest.hs
+++ b/tests/RewriteVerify/RewriteVerifyTest.hs
@@ -33,7 +33,7 @@ findRule rule_list rule_name =
       rule = find (\r -> tentry == ru_name r) rule_list
   in case rule of
       Just r -> r
-      Nothing -> error "not found"
+      Nothing -> error $ "not found " ++ show rule_name
 
 acceptRule :: Config -> State t -> Bindings -> RewriteRule -> IO ()
 acceptRule config init_state bindings rule = do
@@ -56,7 +56,8 @@ good_names = [ "addOneCommutative"
              , "doubleNegative"
              , "maybeForceZero"
              , "maxWithSelf"
-             , "addOneJust" ]
+             , "addOneJust"
+             , "justJust" ]
 
 good_src :: String
 good_src = "tests/RewriteVerify/Correct/SimpleCorrect.hs"
@@ -65,7 +66,9 @@ bad_names :: [String]
 bad_names = [ "badMaybeForce"
             , "badNegation"
             , "badMax"
-            , "badMaxLeft" ]
+            , "badMaxLeft"
+            , "badJust"
+            , "badTuple" ]
 
 bad_src :: String
 bad_src = "tests/RewriteVerify/Incorrect/SimpleIncorrect.hs"


### PR DESCRIPTION
Mostly, this is modify the Symbolic Execution reducer specifically for the verifier, so that it by converts symbolic variables with ADT types to a constructor.  This means that we no longer need caseWrap, which should let us simplify moreRestrictive.