### PR TITLE
Guarded Coinduction

### DIFF
--- a/rewritev/Main.hs
+++ b/rewritev/Main.hs
@@ -50,6 +50,8 @@ runWithArgs as = do
 
   let tentry = T.pack entry
 
+  -- TODO can modify the config here directly
+  -- having a flag is also an option
   config <- getConfig as
 
   let libs = maybeToList m_mapsrc

--- a/rewritev/Main.hs
+++ b/rewritev/Main.hs
@@ -50,8 +50,6 @@ runWithArgs as = do
 
   let tentry = T.pack entry
 
-  -- TODO can modify the config here directly
-  -- having a flag is also an option
   config <- getConfig as
 
   let libs = maybeToList m_mapsrc

--- a/src/G2/Equiv/EquivADT.hs
+++ b/src/G2/Equiv/EquivADT.hs
@@ -10,9 +10,6 @@ import Control.Monad
 
 import G2.Execution.NormalForms
 
--- TODO
-import qualified Debug.Trace as D
-
 proofObligations :: State t ->
                     State t ->
                     Expr ->
@@ -67,7 +64,7 @@ exprPairing s1@(State {expr_env = h1}) s2@(State {expr_env = h2}) e1 e2 pairs =
                      | otherwise -> Nothing
     (Lam _ _ _, _) -> Just (HS.insert (e1, e2) pairs)
     (_, Lam _ _ _) -> Just (HS.insert (e1, e2) pairs)
-    -- TODO assume for now that all types line up between the two expressions
+    -- assume that all types line up between the two expressions
     (Type _, Type _) -> Just pairs
     (Case _ _ _, _) -> Just (HS.insert (e1, e2) pairs)
     (_, Case _ _ _) -> Just (HS.insert (e1, e2) pairs)

--- a/src/G2/Equiv/EquivADT.hs
+++ b/src/G2/Equiv/EquivADT.hs
@@ -43,13 +43,13 @@ exprPairing s1@(State {expr_env = h1}) s2@(State {expr_env = h2}) e1 e2 pairs =
                 let ep = uncurry (exprPairing s1 s2)
                     ep' hs p = ep p hs
                     l = zip l1 l2
-                in foldM ep' pairs l
+                in D.trace "A" $ foldM ep' pairs l
                 else Nothing
     (Data (DataCon d1 _), Data (DataCon d2 _))
-                       | d1 == d2 -> Just pairs
+                       | d1 == d2 -> D.trace "C" $ Just pairs
                        | otherwise -> Nothing
     (Prim p1 _, Prim p2 _) | p1 == Error || p1 == Undefined
-                           , p2 == Error || p2 == Undefined -> Just pairs
+                           , p2 == Error || p2 == Undefined -> D.trace "B" $ Just pairs
     -- extra cases for avoiding Error problems
     (Prim p _, _) | (p == Error || p == Undefined)
                   , isExprValueForm h2 e2 -> Nothing
@@ -57,12 +57,12 @@ exprPairing s1@(State {expr_env = h1}) s2@(State {expr_env = h2}) e1 e2 pairs =
                   , isExprValueForm h1 e1 -> Nothing
     (Prim _ _, _) -> Just (HS.insert (e1, e2) pairs)
     (_, Prim _ _) -> Just (HS.insert (e1, e2) pairs)
-    (App _ _, _) -> Just (HS.insert (e1, e2) pairs)
-    (_, App _ _) -> Just (HS.insert (e1, e2) pairs)
-    (Lit l1, Lit l2) | l1 == l2 -> Just pairs
+    (App _ _, _) -> D.trace "F" $ D.trace (show $ (e1, e2)) $ Just (HS.insert (e1, e2) pairs)
+    (_, App _ _) -> D.trace "G" $ Just (HS.insert (e1, e2) pairs)
+    (Lit l1, Lit l2) | l1 == l2 -> D.trace "D" $ Just pairs
                      | otherwise -> Nothing
     (Lam _ _ _, _) -> Just (HS.insert (e1, e2) pairs)
     (_, Lam _ _ _) -> Just (HS.insert (e1, e2) pairs)
     -- TODO assume for now that all types line up between the two expressions
-    (Type _, Type _) -> Just pairs
+    (Type _, Type _) -> D.trace "E" $ Just pairs
     _ -> error $ "catch-all case\n" ++ show e1 ++ "\n" ++ show e2

--- a/src/G2/Equiv/EquivADT.hs
+++ b/src/G2/Equiv/EquivADT.hs
@@ -43,13 +43,13 @@ exprPairing s1@(State {expr_env = h1}) s2@(State {expr_env = h2}) e1 e2 pairs =
                 let ep = uncurry (exprPairing s1 s2)
                     ep' hs p = ep p hs
                     l = zip l1 l2
-                in D.trace "A" $ foldM ep' pairs l
+                in foldM ep' pairs l
                 else Nothing
     (Data (DataCon d1 _), Data (DataCon d2 _))
-                       | d1 == d2 -> D.trace "C" $ Just pairs
+                       | d1 == d2 -> Just pairs
                        | otherwise -> Nothing
     (Prim p1 _, Prim p2 _) | p1 == Error || p1 == Undefined
-                           , p2 == Error || p2 == Undefined -> D.trace "B" $ Just pairs
+                           , p2 == Error || p2 == Undefined -> Just pairs
     -- extra cases for avoiding Error problems
     (Prim p _, _) | (p == Error || p == Undefined)
                   , isExprValueForm h2 e2 -> Nothing
@@ -57,12 +57,14 @@ exprPairing s1@(State {expr_env = h1}) s2@(State {expr_env = h2}) e1 e2 pairs =
                   , isExprValueForm h1 e1 -> Nothing
     (Prim _ _, _) -> Just (HS.insert (e1, e2) pairs)
     (_, Prim _ _) -> Just (HS.insert (e1, e2) pairs)
-    (App _ _, _) -> D.trace "F" $ D.trace (show $ (e1, e2)) $ Just (HS.insert (e1, e2) pairs)
-    (_, App _ _) -> D.trace "G" $ Just (HS.insert (e1, e2) pairs)
-    (Lit l1, Lit l2) | l1 == l2 -> D.trace "D" $ Just pairs
+    (App _ _, _) -> Just (HS.insert (e1, e2) pairs)
+    (_, App _ _) -> Just (HS.insert (e1, e2) pairs)
+    (Lit l1, Lit l2) | l1 == l2 -> Just pairs
                      | otherwise -> Nothing
     (Lam _ _ _, _) -> Just (HS.insert (e1, e2) pairs)
     (_, Lam _ _ _) -> Just (HS.insert (e1, e2) pairs)
     -- TODO assume for now that all types line up between the two expressions
-    (Type _, Type _) -> D.trace "E" $ Just pairs
+    (Type _, Type _) -> Just pairs
+    -- TODO Tick case
+    (Tick _ e1', Tick _ e2') -> exprPairing s1 s2 e1' e2' pairs
     _ -> error $ "catch-all case\n" ++ show e1 ++ "\n" ++ show e2

--- a/src/G2/Equiv/EquivADT.hs
+++ b/src/G2/Equiv/EquivADT.hs
@@ -1,4 +1,11 @@
-module G2.Equiv.EquivADT (proofObligations) where
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+-- TODO not sure if I need these
+
+module G2.Equiv.EquivADT (
+    proofObligations
+  , Obligation (..)
+  ) where
 
 import G2.Language
 import qualified G2.Language.ExprEnv as E
@@ -10,31 +17,42 @@ import Control.Monad
 
 import G2.Execution.NormalForms
 
+import GHC.Generics (Generic)
+import Data.Data
+import Data.Hashable
+
+-- TODO the bool is True if prev_g can be used
+data Obligation = Ob Bool Expr Expr deriving (Show, Eq, Read, Generic, Typeable, Data)
+
+instance Hashable Obligation
+
 proofObligations :: State t ->
                     State t ->
                     Expr ->
                     Expr ->
-                    Maybe (HS.HashSet (Expr, Expr))
+                    Maybe (HS.HashSet Obligation)
 proofObligations s1 s2 e1 e2 =
-  exprPairing s1 s2 e1 e2 HS.empty
+  exprPairing s1 s2 e1 e2 HS.empty False
 
+-- TODO also need a bool passed downward to mark children?
 exprPairing :: State t ->
                State t ->
                Expr ->
                Expr ->
-               HS.HashSet (Expr, Expr) ->
-               Maybe (HS.HashSet (Expr, Expr))
-exprPairing s1@(State {expr_env = h1}) s2@(State {expr_env = h2}) e1 e2 pairs =
+               HS.HashSet Obligation ->
+               Bool ->
+               Maybe (HS.HashSet Obligation)
+exprPairing s1@(State {expr_env = h1}) s2@(State {expr_env = h2}) e1 e2 pairs child =
   case (e1, e2) of
     _ | e1 == e2 -> Just pairs
     -- ignore all Ticks
-    (Tick _ e1', _) -> exprPairing s1 s2 e1' e2 pairs
-    (_, Tick _ e2') -> exprPairing s1 s2 e1 e2' pairs
-    (Var i, _) | E.isSymbolic (idName i) h1 -> Just (HS.insert (e1, e2) pairs)
-               | Just e <- E.lookup (idName i) h1 -> exprPairing s1 s2 e e2 pairs
+    (Tick _ e1', _) -> exprPairing s1 s2 e1' e2 pairs False
+    (_, Tick _ e2') -> exprPairing s1 s2 e1 e2' pairs False
+    (Var i, _) | E.isSymbolic (idName i) h1 -> Just (HS.insert (Ob child e1 e2) pairs)
+               | Just e <- E.lookup (idName i) h1 -> exprPairing s1 s2 e e2 pairs False
                | otherwise -> error "unmapped variable"
-    (_, Var i) | E.isSymbolic (idName i) h2 -> Just (HS.insert (e1, e2) pairs)
-               | Just e <- E.lookup (idName i) h2 -> exprPairing s1 s2 e1 e pairs
+    (_, Var i) | E.isSymbolic (idName i) h2 -> Just (HS.insert (Ob child e1 e2) pairs)
+               | Just e <- E.lookup (idName i) h2 -> exprPairing s1 s2 e1 e pairs False
                | otherwise -> error "unmapped variable"
     -- See note in `moreRestrictive` regarding comparing DataCons
     (App _ _, App _ _)
@@ -42,7 +60,7 @@ exprPairing s1@(State {expr_env = h1}) s2@(State {expr_env = h2}) e1 e2 pairs =
         , (Data (DataCon d2 _)):l2 <- unApp e2 ->
             if d1 == d2 then
                 let ep = uncurry (exprPairing s1 s2)
-                    ep' hs p = ep p hs
+                    ep' hs p = ep p hs True
                     l = zip l1 l2
                 in foldM ep' pairs l
                 else Nothing
@@ -56,16 +74,18 @@ exprPairing s1@(State {expr_env = h1}) s2@(State {expr_env = h2}) e1 e2 pairs =
                   , isExprValueForm h2 e2 -> Nothing
     (_, Prim p _) | (p == Error || p == Undefined)
                   , isExprValueForm h1 e1 -> Nothing
-    (Prim _ _, _) -> Just (HS.insert (e1, e2) pairs)
-    (_, Prim _ _) -> Just (HS.insert (e1, e2) pairs)
-    (App _ _, _) -> Just (HS.insert (e1, e2) pairs)
-    (_, App _ _) -> Just (HS.insert (e1, e2) pairs)
+    (Prim _ _, _) -> Just (HS.insert (Ob child e1 e2) pairs)
+    (_, Prim _ _) -> Just (HS.insert (Ob child e1 e2) pairs)
+    (App _ _, _) -> Just (HS.insert (Ob child e1 e2) pairs)
+    (_, App _ _) -> Just (HS.insert (Ob child e1 e2) pairs)
     (Lit l1, Lit l2) | l1 == l2 -> Just pairs
                      | otherwise -> Nothing
-    (Lam _ _ _, _) -> Just (HS.insert (e1, e2) pairs)
-    (_, Lam _ _ _) -> Just (HS.insert (e1, e2) pairs)
+    -- TODO double lambda case necessary?
+    (Lam _ _ _, Lam _ _ _) -> Just (HS.insert (Ob True e1 e2) pairs)
+    (Lam _ _ _, _) -> Just (HS.insert (Ob child e1 e2) pairs)
+    (_, Lam _ _ _) -> Just (HS.insert (Ob child e1 e2) pairs)
     -- assume that all types line up between the two expressions
     (Type _, Type _) -> Just pairs
-    (Case _ _ _, _) -> Just (HS.insert (e1, e2) pairs)
-    (_, Case _ _ _) -> Just (HS.insert (e1, e2) pairs)
+    (Case _ _ _, _) -> Just (HS.insert (Ob child e1 e2) pairs)
+    (_, Case _ _ _) -> Just (HS.insert (Ob child e1 e2) pairs)
     _ -> error $ "catch-all case\n" ++ show e1 ++ "\n" ++ show e2

--- a/src/G2/Equiv/EquivADT.hs
+++ b/src/G2/Equiv/EquivADT.hs
@@ -21,8 +21,9 @@ import GHC.Generics (Generic)
 import Data.Data
 import Data.Hashable
 
--- TODO the bool is True if prev_g can be used
-data Obligation = Ob Bool Expr Expr deriving (Show, Eq, Read, Generic, Typeable, Data)
+-- the bool is True if guarded coinduction can be used
+data Obligation = Ob Bool Expr Expr
+                  deriving (Show, Eq, Read, Generic, Typeable, Data)
 
 instance Hashable Obligation
 
@@ -34,7 +35,6 @@ proofObligations :: State t ->
 proofObligations s1 s2 e1 e2 =
   exprPairing s1 s2 e1 e2 HS.empty False
 
--- TODO also need a bool passed downward to mark children?
 exprPairing :: State t ->
                State t ->
                Expr ->

--- a/src/G2/Equiv/EquivADT.hs
+++ b/src/G2/Equiv/EquivADT.hs
@@ -30,7 +30,7 @@ exprPairing :: State t ->
 exprPairing s1@(State {expr_env = h1}) s2@(State {expr_env = h2}) e1 e2 pairs =
   case (e1, e2) of
     _ | e1 == e2 -> Just pairs
-    -- TODO ignore all Ticks now?
+    -- ignore all Ticks
     (Tick _ e1', _) -> exprPairing s1 s2 e1' e2 pairs
     (_, Tick _ e2') -> exprPairing s1 s2 e1 e2' pairs
     (Var i, _) | E.isSymbolic (idName i) h1 -> Just (HS.insert (e1, e2) pairs)
@@ -69,11 +69,6 @@ exprPairing s1@(State {expr_env = h1}) s2@(State {expr_env = h2}) e1 e2 pairs =
     (_, Lam _ _ _) -> Just (HS.insert (e1, e2) pairs)
     -- TODO assume for now that all types line up between the two expressions
     (Type _, Type _) -> Just pairs
-    -- TODO handle Case expressions
     (Case _ _ _, _) -> Just (HS.insert (e1, e2) pairs)
     (_, Case _ _ _) -> Just (HS.insert (e1, e2) pairs)
-    -- TODO will need state modification for that
-    -- TODO allow changes in order?
-    -- TODO Tick case
-    --(Tick _ e1', Tick _ e2') -> exprPairing s1 s2 e1' e2' pairs
     _ -> error $ "catch-all case\n" ++ show e1 ++ "\n" ++ show e2

--- a/src/G2/Equiv/G2Calls.hs
+++ b/src/G2/Equiv/G2Calls.hs
@@ -87,8 +87,9 @@ instance Reducer EnforceProgressR (Maybe Int) EquivTracker where
 
 -- TODO delete GuardedHalter code
 argCount :: Type -> Int
-argCount (TyFun _ t) = 1 + argCount t
-argCount _ = 0
+--argCount (TyFun _ t) = 1 + argCount t
+--argCount _ = 0
+argCount = length . spArgumentTypes . PresType
 
 exprFullApp :: ExprEnv -> Expr -> Bool
 exprFullApp h e | (Var (Id n t)):_ <- unApp e

--- a/src/G2/Equiv/G2Calls.hs
+++ b/src/G2/Equiv/G2Calls.hs
@@ -49,7 +49,7 @@ rewriteRedHaltOrd solver simplifier config =
             Nothing -> SomeReducer (StdRed share solver simplifier :<~ ConcSymReducer :<~? EquivReducer)
      , SomeHalter
          (DiscardIfAcceptedTag state_name
-         :<~> AcceptIfViolatedHalter)
+         :<~> GuardedHalter)
      , SomeOrderer $ PickLeastUsedOrderer)
 
 type StateET = State EquivTracker

--- a/src/G2/Equiv/G2Calls.hs
+++ b/src/G2/Equiv/G2Calls.hs
@@ -63,15 +63,8 @@ data EnforceProgressR = EnforceProgressR
 
 data EnforceProgressH = EnforceProgressH
 
--- TODO the rv here is irrelevant
--- get the MaybeInt from the EquivTracker instead
--- TODO may need to alter the state as well
--- TODO also check for FAF here?
 instance Reducer EnforceProgressR (Maybe Int) EquivTracker where
     initReducer _ _ = Nothing
-    -- TODO never gets called currently
-    -- later:  always No Tick
-    -- TODO which here gets NoProgress?
     redRules r rv s@(State { curr_expr = CurrExpr _ e
                            , num_steps = n
                            , track = EquivTracker et m })
@@ -79,20 +72,18 @@ instance Reducer EnforceProgressR (Maybe Int) EquivTracker where
         let s' = s { track = EquivTracker et (Just n) }
         in
         case (e, m) of
-        --case (e, rv) of
             (Tick (NamedLoc (Name p _ _ _)) _, Nothing) ->
-                trace "Tick Nothing" $
                 if p == T.pack "STACK"
                 then return (InProgress, [(s', Just n)], b, r)
                 else return (NoProgress, [(s, Nothing)], b, r)
-            -- TODO this case should be unreachable
-            -- rv Nothing, Tick Nothing, Tick Just, No Tick ...
+            -- TODO condense these into one case?
+            -- TODO n > n0 + 1
+            -- then again, it might not matter at all here
             (Tick (NamedLoc (Name p _ _ _)) _, Just n0) ->
-                trace "Tick Just" $
                 if p == T.pack "STACK" && n > n0
                 then return (InProgress, [(s', Just n)], b, r)
                 else return (NoProgress, [(s, m)], b, r)
-            _ -> trace "No Tick" $ return (NoProgress, [(s, rv)], b, r)
+            _ -> return (NoProgress, [(s, rv)], b, r)
 
 -- TODO delete GuardedHalter code
 argCount :: Type -> Int

--- a/src/G2/Equiv/G2Calls.hs
+++ b/src/G2/Equiv/G2Calls.hs
@@ -130,6 +130,7 @@ instance Reducer EquivReducer () EquivTracker where
                           , symbolic_ids = symbs
                           , track = EquivTracker et m })
                  b@(Bindings { name_gen = ng })
+        -- | trace ("isSymFuncApp " ++ (show e) ++ "\n" ++ (show $ isSymFuncApp eenv e)) $
         | isSymFuncApp eenv e =
             let
                 -- We inline variables to have a higher chance of hitting in the Equiv Tracker
@@ -156,8 +157,13 @@ instance Reducer EquivReducer () EquivTracker where
 
 isSymFuncApp :: ExprEnv -> Expr -> Bool
 isSymFuncApp eenv e
-    | Var (Id f t):es@(_:_) <- unApp e = E.isSymbolic f eenv && hasFuncType (PresType t)
-    | otherwise = False
+    -- | Var (Id f t):es@(_:_) <- unApp e = trace ("f = " ++ (show f) ++ " " ++ (show $ E.lookupConcOrSym f eenv) ++ " " ++ (show $ hasFuncType (PresType t))) (E.isSymbolic f eenv && hasFuncType (PresType t))
+    | v@(Var _):es@(_:_) <- unApp e
+    , (Var (Id f t)) <- inlineVars eenv v = trace ("f = " ++ (show f) ++ " " ++ (show $ E.lookupConcOrSym f eenv) ++ " " ++ (show $ hasFuncType (PresType t))) $
+                                            E.isSymbolic f eenv && hasFuncType (PresType t)
+    -- TODO this case doesn't matter
+    -- | Var (Id f t):es@(_:_) <- unApp e = trace ("QQ " ++ (show $ E.isSymbolic f eenv && hasFuncType (PresType t))) $ trace (show f) $ E.isSymbolic f eenv && hasFuncType (PresType t)
+    | otherwise = {- trace "RR" $ trace (show e) -} False
 
 inlineApp :: ExprEnv -> Expr -> Expr
 inlineApp eenv = mkApp . map (inlineVars eenv) . unApp

--- a/src/G2/Equiv/G2Calls.hs
+++ b/src/G2/Equiv/G2Calls.hs
@@ -102,8 +102,8 @@ exprFullApp h e | (Var (Id n t)):_ <- unApp e
                 -- We want to avoid storing a previous state using f,
                 -- having the symbolic execution inline g, and then deciding that 
                 -- the two states match and are sufficient for verification to succeed.  
-                , Just e <- E.lookup n h
-                , not (isVar e) = length (unApp e) == 1 + argCount t
+                , Just e' <- E.lookup n h
+                , not (isVar e') = length (unApp e) == 1 + argCount t
 exprFullApp _ _ = False
 
 isVar :: Expr -> Bool
@@ -125,7 +125,15 @@ instance Halter EnforceProgressH () EquivTracker where
             -- Execution needs to take strictly more than one step beyond the
             -- point when it reaches the Tick because the act of unwrapping the
             -- expression inside the Tick counts as one step.
-            Just n0 -> if (isExecValueForm s) || (exprFullApp h e)
+            Just n0 -> do
+                case unApp e of
+                    (Var (Id n t)):_ ->
+                        putStrLn $ "stopRed\nE.lookup n h = " ++ show (E.lookup n h)
+                                    ++ "\nexprFullApp = " ++ show (exprFullApp h e)
+                                    ++ "\nargCount t = " ++ show (argCount t)
+                                    ++ "\nlength (unApp e) = " ++ show (length (unApp e))
+                    _ -> return ()
+                if (isExecValueForm s) || (exprFullApp h e)
                        then return (if n' > n0 + 1 then Accept else Continue)
                        else return Continue
     stepHalter _ _ _ _ _ = ()

--- a/src/G2/Equiv/G2Calls.hs
+++ b/src/G2/Equiv/G2Calls.hs
@@ -99,7 +99,6 @@ instance Halter EnforceProgressH (Maybe Int) EquivTracker where
     initHalt _ _ = Nothing
     updatePerStateHalt _ _ _ _ = Nothing
     stopRed _ _ _ s =
-        --trace "rv Just" $
         let CurrExpr _ e = curr_expr s
             n' = num_steps s
             EquivTracker _ m = track s

--- a/src/G2/Equiv/G2Calls.hs
+++ b/src/G2/Equiv/G2Calls.hs
@@ -28,8 +28,9 @@ runG2ForRewriteV state config bindings = do
     let simplifier = IdSimplifier
         sym_ids = symbolic_ids state
         sym_names = map idName sym_ids
-        sym_config = addSearchNames (names $ track state)
-                   $ addSearchNames (input_names bindings) emptyMemConfig
+        sym_config = PreserveAllMC
+        -- sym_config = addSearchNames (names $ track state)
+        --            $ addSearchNames (input_names bindings) emptyMemConfig
 
         state' = state { track = (track state) { saw_tick = Nothing } }
 

--- a/src/G2/Equiv/G2Calls.hs
+++ b/src/G2/Equiv/G2Calls.hs
@@ -81,7 +81,6 @@ instance Reducer EnforceProgressR () EquivTracker where
                 then return (InProgress, [(s', ())], b, r)
                 else return (NoProgress, [(s, ())], b, r)
             -- TODO condense these into one case?
-            -- TODO n > n0 + 1
             -- then again, it might not matter at all here
             (Tick (NamedLoc (Name p _ _ _)) _, Just n0) ->
                 if p == T.pack "STACK" && n > n0 + 1
@@ -89,7 +88,6 @@ instance Reducer EnforceProgressR () EquivTracker where
                 else return (NoProgress, [(s, ())], b, r)
             _ -> return (NoProgress, [(s, rv)], b, r)
 
--- TODO delete GuardedHalter code
 argCount :: Type -> Int
 argCount = length . spArgumentTypes . PresType
 
@@ -115,7 +113,6 @@ isVar :: Expr -> Bool
 isVar (Var _) = True
 isVar _ = False
 
--- TODO changed t to EquivTracker
 instance Halter EnforceProgressH () EquivTracker where
     initHalt _ _ = ()
     updatePerStateHalt _ _ _ _ = ()
@@ -145,7 +142,6 @@ emptyEquivTracker = EquivTracker HM.empty Nothing
 
 data EquivReducer = EquivReducer
 
--- TODO new variable m
 instance Reducer EquivReducer () EquivTracker where
     initReducer _ _ = ()
     redRules r _ s@(State { expr_env = eenv
@@ -197,7 +193,6 @@ inlineVars' seen eenv (Var (Id n _))
 inlineVars' seen eenv (App e1 e2) = App (inlineVars' seen eenv e1) (inlineVars' seen eenv e2)
 inlineVars' _ _ e = e
 
--- TODO not all m usage here and elsewhere may be correct
 instance ASTContainer EquivTracker Expr where
     containedASTs (EquivTracker hm _) = HM.keys hm
     modifyContainedASTs f (EquivTracker hm m) =

--- a/src/G2/Equiv/InitRewrite.hs
+++ b/src/G2/Equiv/InitRewrite.hs
@@ -5,6 +5,8 @@ import qualified G2.Language.ExprEnv as E
 import qualified G2.Language.Typing as T
 import qualified G2.Language.Expr as X
 
+import G2.Execution.Memory
+
 addSymbolic :: Id -> ExprEnv -> ExprEnv
 addSymbolic i =
   E.insertSymbolic (idName i) i
@@ -18,7 +20,7 @@ initWithRHS s b r =
            }
       b' = b { input_names = map idName $ ru_bndrs r }
   in
-  (s', b')
+  markAndSweepPreserving emptyMemConfig s' b'
 
 initWithLHS :: State t -> Bindings -> RewriteRule -> (State t, Bindings)
 initWithLHS s b r =
@@ -39,4 +41,4 @@ initWithLHS s b r =
                        }
                   b' = b { input_names = map idName $ ru_bndrs r }
               in
-              (s', b')
+              markAndSweepPreserving emptyMemConfig s' b'

--- a/src/G2/Equiv/Verifier.hs
+++ b/src/G2/Equiv/Verifier.hs
@@ -68,6 +68,8 @@ runSymExec config s1 s2 = do
   let s1' = s1 { rules = [], num_steps = 0 }
       s2' = s2 { rules = [], num_steps = 0 }
 
+  CM.liftIO $ putStrLn "runSymExec"
+
   ct1 <- CM.liftIO $ getCurrentTime
   let config' = config -- { logStates = Just $ "a_state" ++ show ct1 }
   --let s1' = prepareState s1
@@ -176,7 +178,7 @@ prepareState :: StateET -> StateET
 prepareState s =
   let CurrExpr er e = curr_expr s
   in s {
-    curr_expr = CurrExpr er $ exprWrap (exec_stack s) $ e
+    curr_expr = CurrExpr Evaluate $ exprWrap (exec_stack s) $ e
   , num_steps = 0
   , rules = []
   , exec_stack = Stck.empty
@@ -290,8 +292,8 @@ obligationStates s1 s2 =
   let CurrExpr er1 _ = curr_expr s1
       CurrExpr er2 _ = curr_expr s2
       stateWrap (e1, e2) =
-        ( s1 { curr_expr = CurrExpr er1 e1 }
-        , s2 { curr_expr = CurrExpr er2 e2 } )
+        ( s1 { curr_expr = CurrExpr Evaluate e1 }
+        , s2 { curr_expr = CurrExpr Evaluate e2 } )
   in case getObligations s1 s2 of
       Nothing -> Nothing
       Just obs -> Just . map stateWrap
@@ -366,11 +368,11 @@ checkRule config init_state bindings rule = do
       CurrExpr er_r e_r = curr_expr rewrite_state_r
       rewrite_state_l' = rewrite_state_l {
                            track = emptyEquivTracker
-                         , curr_expr = CurrExpr er_l $ tickWrap $ e_l
+                         , curr_expr = CurrExpr Evaluate $ tickWrap $ e_l
                          }
       rewrite_state_r' = rewrite_state_r {
                            track = emptyEquivTracker
-                         , curr_expr = CurrExpr er_r $ tickWrap $ e_r
+                         , curr_expr = CurrExpr Evaluate $ tickWrap $ e_r
                          }
       ns_l = HS.fromList $ E.keys $ expr_env rewrite_state_l
       ns_r = HS.fromList $ E.keys $ expr_env rewrite_state_r

--- a/src/G2/Equiv/Verifier.hs
+++ b/src/G2/Equiv/Verifier.hs
@@ -250,10 +250,6 @@ verifyLoop' solver ns_pair s1 s2 prev_u prev_g =
           putStr "J! "
           putStrLn $ show (exprExtract s1, exprExtract s2)
           -- TODO
-          putStrLn "FSFS"
-          putStrLn $ show $ E.lookup fs_name (expr_env s1)
-          putStrLn $ show $ E.lookup fs_name (expr_env s2)
-          -- TODO
           --putStrLn "$$$"
           --putStrLn $ show $ E.lookupConcOrSym f_name (expr_env s1)
           --putStrLn $ show $ E.lookupConcOrSym f_name (expr_env s2)
@@ -269,7 +265,7 @@ verifyLoop' solver ns_pair s1 s2 prev_u prev_g =
           putStr "O: "
           putStrLn $ show ready_exprs
           putStr "NR: "
-          putStrLn $ show $ length $ show $ map (\(r1, r2) -> (exprExtract r1, exprExtract r2)) not_ready
+          putStrLn $ show $ map (\(r1, r2) -> (exprExtract r1, exprExtract r2)) not_ready
           putStr "OBS: "
           putStrLn $ show $ length obs
           res <- checkObligations solver s1 s2 ready_exprs
@@ -361,13 +357,8 @@ checkRule config init_state bindings rule = do
       ns_l = HS.fromList $ E.keys $ expr_env rewrite_state_l
       ns_r = HS.fromList $ E.keys $ expr_env rewrite_state_r
   S.SomeSolver solver <- initSolver config
-  -- TODO
-  putStrLn $ show rule
-  putStrLn "-$-$-$-"
-  putStrLn $ show $ E.lookupConcOrSym f_name (expr_env rewrite_state_l)
-  putStrLn $ show $ E.lookupConcOrSym f_name (expr_env rewrite_state_r)
-  --putStrLn $ show $ curr_expr rewrite_state_l'
-  --putStrLn $ show $ curr_expr rewrite_state_r'
+  putStrLn $ show $ curr_expr rewrite_state_l'
+  putStrLn $ show $ curr_expr rewrite_state_r'
   -- TODO do we know that both sides are in SWHNF at the start?
   -- Could that interfere with the results?
   let prev_u = filter pairNotEVF [(rewrite_state_l', rewrite_state_r')]

--- a/src/G2/Equiv/Verifier.hs
+++ b/src/G2/Equiv/Verifier.hs
@@ -395,13 +395,13 @@ moreRestrictive s1@(State {expr_env = h1}) s2@(State {expr_env = h2}) ns hm e1 e
     -- "forall a . a" is the same type as "forall b . b", but fails a syntactic check.
     (Data (DataCon d1 _), Data (DataCon d2 _))
                                   | d1 == d2 -> Just hm
-                                  | otherwise -> {- trace ("CASE D" ++ show d1) -} Nothing
+                                  | otherwise -> Nothing
     -- TODO potential problems with type equality checking?
     (Prim p1 t1, Prim p2 t2) | p1 == p2
                              , t1 == t2 -> Just hm
-                             | otherwise -> {- trace ("CASE E" ++ show p1) -} Nothing
+                             | otherwise -> Nothing
     (Lit l1, Lit l2) | l1 == l2 -> Just hm
-                     | otherwise -> {- trace ("CASE F" ++ show l1) -} Nothing
+                     | otherwise -> Nothing
     -- TODO I presume I need syntactic equality for lambda expressions
     -- LamUse is a simple variant
     -- TODO new symbolic variables inserted
@@ -413,7 +413,7 @@ moreRestrictive s1@(State {expr_env = h1}) s2@(State {expr_env = h2}) ns hm e1 e
                       s2' = s2 { expr_env = symInsert i2 h2 }
                   in
                   moreRestrictive s1' s2' ns hm b1 b2
-                | otherwise -> {- trace ("CASE G" ++ show i1) -} Nothing
+                | otherwise -> Nothing
     -- TODO ignore types, like in exprPairing?
     (Type _, Type _) -> Just hm
     (Case e1' i1 a1, Case e2' i2 a2)
@@ -484,12 +484,7 @@ mrHelper :: State t ->
             Maybe (HM.HashMap Id Expr)
 mrHelper _ _ _ Nothing = Nothing
 mrHelper s1 s2 ns (Just hm) =
-  let CurrExpr _ e1 = curr_expr s1
-      CurrExpr _ e2 = curr_expr s2
-      --res = moreRestrictive s1 s2 ns hm e1 e2
-  in
-  moreRestrictive s1 s2 ns hm e1 e2
-  --trace (show (isJust res)) res
+  moreRestrictive s1 s2 ns hm (exprExtract s1) (exprExtract s2)
 
 moreRestrictivePair :: (HS.HashSet Name, HS.HashSet Name) ->
                        [(State t, State t)] ->

--- a/src/G2/Equiv/Verifier.hs
+++ b/src/G2/Equiv/Verifier.hs
@@ -315,10 +315,14 @@ checkObligations :: S.Solver solver =>
                     HS.HashSet (Expr, Expr) ->
                     IO (S.Result () ())
 checkObligations solver s1 s2 obligation_set | not $ HS.null obligation_set =
-    case obligationWrap obligation_set of
+    case obligationWrap $ modifyASTs stripTicks obligation_set of
         Nothing -> applySolver solver P.empty s1 s2
         Just allPO -> applySolver solver (P.insert allPO P.empty) s1 s2
   | otherwise = return $ S.UNSAT ()
+
+stripTicks :: Expr -> Expr
+stripTicks (Tick _ e) = e
+stripTicks e = e
 
 applySolver :: S.Solver solver =>
                solver ->

--- a/src/G2/Execution/Reducer.hs
+++ b/src/G2/Execution/Reducer.hs
@@ -365,15 +365,6 @@ instance Reducer ConcSymReducer () t where
                    b@(Bindings { name_gen = ng })
         | E.isSymbolic n eenv
         , Just (dc_symbs, ng') <- arbDC tenv ng t = do
-            -- TODO printing for debugging
-            -- same expr over and over
-            -- symbolic ID list keeps getting longer
-            putStr "EXPR "
-            putStrLn $ show $ Var (Id n t)
-            --putStr "SYM_IDS "
-            --putStrLn $ show symbs
-            putStr "SYMBS "
-            putStrLn $ show dc_symbs
             let 
                 xs = map (\(e, symbs') ->
                                 s   { curr_expr = CurrExpr Evaluate e

--- a/src/G2/Execution/Reducer.hs
+++ b/src/G2/Execution/Reducer.hs
@@ -710,7 +710,8 @@ instance Halter GuardedHalter () t where
         in
         case (isExecValueForm s) || (exprFullApp e) of
             True
-                | Stck.null $ exec_stack s -> return Accept
+                | Stck.null $ exec_stack s
+                , num_steps s /= 0 -> return Accept
                 | otherwise -> return Continue
             False -> return Continue
     stepHalter _ _ _ _ _ = ()

--- a/src/G2/Language/ExprEnv.hs
+++ b/src/G2/Language/ExprEnv.hs
@@ -67,6 +67,7 @@ import qualified Data.Text as T
 
 data ConcOrSym = Conc Expr
                | Sym Id
+               deriving (Show)
 
 -- From a user perspective, `ExprEnv`s are mappings from `Name` to
 -- `Expr`s. however, there are two complications:

--- a/tests/RewriteVerify/Correct/CoinductionCorrect.hs
+++ b/tests/RewriteVerify/Correct/CoinductionCorrect.hs
@@ -10,7 +10,6 @@ cons n (!l) = n:l
 intForce :: [Int] -> [Int]
 intForce [] = []
 intForce (h:t) = cons h $ intForce t
---intForce (h : (!t)) = h:(intForce t)
 
 intDrop :: Int -> [Int] -> [Int]
 intDrop 0 l = l
@@ -45,9 +44,6 @@ p1 = (+ 1)
 t2 :: Int -> Int
 t2 = (* 2)
 
--- TODO takeDropCancel is bad as it is now
--- doesn't work for an undefined list or a negative int
--- same for mapTake?  No, it should be lazy on both sides
 {-# RULES
 "doubleMap" forall l . intMap p1 (intMap t2 l) = intMap (p1 . t2) l
 "mapIterate" forall n . intMap p1 (intIterate p1 n) = intIterate p1 (p1 n)

--- a/tests/RewriteVerify/Correct/CoinductionCorrect.hs
+++ b/tests/RewriteVerify/Correct/CoinductionCorrect.hs
@@ -10,6 +10,7 @@ cons n (!l) = n:l
 intForce :: [Int] -> [Int]
 intForce [] = []
 intForce (h:t) = cons h $ intForce t
+--intForce (h : (!t)) = h:(intForce t)
 
 intDrop :: Int -> [Int] -> [Int]
 intDrop 0 l = l

--- a/tests/RewriteVerify/Correct/HigherOrderCorrect.hs
+++ b/tests/RewriteVerify/Correct/HigherOrderCorrect.hs
@@ -15,15 +15,27 @@ compose :: (Int -> Int) -> (Int -> Int) -> Int -> Int
 compose f g x = f (g x)
 
 intMap :: (Int -> Int) -> [Int] -> [Int]
---intMap = Data.List.map
 intMap _ [] = []
 intMap f (h:t) = (f h) : (intMap f t)
 
 intIterate :: (Int -> Int) -> Int -> [Int]
 intIterate f n = n : (intIterate f (f n))
 
+-- TODO
+intFilter :: (Int -> Bool) -> [Int] -> [Int]
+intFilter _ [] = []
+intFilter f (h:t) = if f h then h:(intFilter f t) else intFilter f t
+
+nonneg :: Int -> Bool
+nonneg x = x >= 0
+
+p1 :: Int -> Int
+p1 x = x + 1
+
 {-# RULES
 "doubleMap" forall f g l . intMap f (intMap g l) = intMap (compose f g) l
 "mapIterate" forall f  n . intMap f (intIterate f n) = intIterate f (f n)
 "mapTake" forall f n l . intMap f (intTake n l) = intTake n (intMap f l)
+"mapFilter" forall f g l . intMap g (intFilter (f . g) l) = intFilter f (intMap g l)
+"mf" forall l . intMap p1 (intFilter (nonneg . p1) l) = intFilter nonneg (intMap p1 l)
   #-}

--- a/tests/RewriteVerify/Correct/HigherOrderCorrect.hs
+++ b/tests/RewriteVerify/Correct/HigherOrderCorrect.hs
@@ -16,15 +16,15 @@ compose f g x = f (g x)
 
 intMap :: (Int -> Int) -> [Int] -> [Int]
 intMap _ [] = []
-intMap f (h:t) = (f h) : (intMap f t)
+intMap p (h:t) = (p h) : (intMap p t)
 
 intIterate :: (Int -> Int) -> Int -> [Int]
-intIterate f n = n : (intIterate f (f n))
+intIterate q n = n : (intIterate q (q n))
 
 -- TODO
 intFilter :: (Int -> Bool) -> [Int] -> [Int]
 intFilter _ [] = []
-intFilter f (h:t) = if f h then h:(intFilter f t) else intFilter f t
+intFilter r (h:t) = if r h then h:(intFilter r t) else intFilter r t
 
 nonneg :: Int -> Bool
 nonneg x = x >= 0

--- a/tests/RewriteVerify/Correct/HigherOrderCorrect.hs
+++ b/tests/RewriteVerify/Correct/HigherOrderCorrect.hs
@@ -2,7 +2,6 @@ module CoinductionCorrect where
 
 import Data.List
 
--- TODO strictness might be an issue here
 intTake :: Int -> [Int] -> [Int]
 intTake 0 _ = []
 intTake n (h:t) =
@@ -21,7 +20,6 @@ intMap p (h:t) = (p h) : (intMap p t)
 intIterate :: (Int -> Int) -> Int -> [Int]
 intIterate q n = n : (intIterate q (q n))
 
--- TODO
 intFilter :: (Int -> Bool) -> [Int] -> [Int]
 intFilter _ [] = []
 intFilter r (h:t) = if r h then h:(intFilter r t) else intFilter r t

--- a/tests/RewriteVerify/Correct/TreeCorrect.hs
+++ b/tests/RewriteVerify/Correct/TreeCorrect.hs
@@ -32,7 +32,6 @@ bst (BBranch i t0@(BBranch j _ _) t1@(BBranch k _ _)) =
 "doubleMapTree" forall bt . bmap p1 (bmap t2 bt) = bmap (p1 . t2) bt
   #-}
 
--- these two rules take a long time to verify, but it does succeed
 {-# RULES
 "bstPlus" forall bt . bst (bmap p1 bt) = bst bt
 "bstTimes" forall bt . bst (bmap t2 bt) = bst bt

--- a/tests/RewriteVerify/Correct/TreeCorrect.hs
+++ b/tests/RewriteVerify/Correct/TreeCorrect.hs
@@ -1,0 +1,39 @@
+module TreeCorrect where
+
+data SimpleTree = SLeaf
+                | SBranch SimpleTree SimpleTree
+
+treeSize :: SimpleTree -> Int
+treeSize SLeaf = 1
+treeSize (SBranch st1 st2) = 1 + (treeSize st1) + (treeSize st2)
+
+data BTree t = BLeaf
+             | BBranch t (BTree t) (BTree t)
+
+bmap :: (a -> b) -> BTree a -> BTree b
+bmap _ BLeaf = BLeaf
+bmap f (BBranch e t1 t2) = BBranch (f e) (bmap f t1) (bmap f t2)
+
+p1 :: Int -> Int
+p1 = (+ 1)
+
+t2 :: Int -> Int
+t2 = (* 2)
+
+bst :: BTree Int -> Bool
+bst BLeaf = True
+bst (BBranch i t0@(BBranch j _ _) BLeaf) = i >= j && bst t0
+bst (BBranch i BLeaf t0@(BBranch k _ _)) = i <= k && bst t0
+bst (BBranch i t0@(BBranch j _ _) t1@(BBranch k _ _)) =
+  i >= j && i <= k && bst t0 && bst t1
+
+{-# RULES
+"doubleTree" forall st . treeSize (SBranch st st) = 1 + (2 * treeSize st)
+"doubleMapTree" forall bt . bmap p1 (bmap t2 bt) = bmap (p1 . t2) bt
+  #-}
+
+-- these two rules take a long time to verify, but it does succeed
+{-# RULES
+"bstPlus" forall bt . bst (bmap p1 bt) = bst bt
+"bstTimes" forall bt . bst (bmap t2 bt) = bst bt
+  #-}

--- a/tests/RewriteVerify/Incorrect/CoinductionIncorrect.hs
+++ b/tests/RewriteVerify/Incorrect/CoinductionIncorrect.hs
@@ -57,6 +57,9 @@ f x = x + 1
 g :: Int -> Int
 g x = x + 2
 
+nonterm :: Bool -> Bool
+nonterm b = nonterm b
+
 {-# RULES
 "doubleMapBackward" forall l . intMap p1 (intMap t2 l) = intMap (t2 . p1) l
 "badMapIterate" forall n . intMap p1 (intIterate p1 n) = intIterate p1 n
@@ -72,4 +75,5 @@ g x = x + 2
 "doubleTake" forall n m l . intTake n (intTake m l) = intTake n l
 "badDoubleReverse" forall l . intReverse (intReverse l) = l
 "takeDropCancel" forall n l . intDrop n (intTake n l) = []
+"badBool" forall b . nonterm b = True
   #-}

--- a/tests/RewriteVerify/Incorrect/CoinductionIncorrect.hs
+++ b/tests/RewriteVerify/Incorrect/CoinductionIncorrect.hs
@@ -48,10 +48,21 @@ p1 = (+ 1)
 t2 :: Int -> Int
 t2 = (* 2)
 
+-- TODO new example
+con :: Int -> Int
+con x = x
+
+f :: Int -> Int
+f x = x + 1
+
+g :: Int -> Int
+g x = x + 2
+
 {-# RULES
 "doubleMapBackward" forall l . intMap p1 (intMap t2 l) = intMap (t2 . p1) l
 "badMapIterate" forall n . intMap p1 (intIterate p1 n) = intIterate p1 n
 "badMapTake" forall n l . intMap p1 (intTake n l) = intTake n (intMap t2 l)
+"badCon" forall x . con (f x) = con (g x)
   #-}
 
 -- some of these rules are incorrect only because of laziness

--- a/tests/RewriteVerify/Incorrect/CoinductionIncorrect.hs
+++ b/tests/RewriteVerify/Incorrect/CoinductionIncorrect.hs
@@ -10,6 +10,7 @@ cons n (!l) = n:l
 intForce :: [Int] -> [Int]
 intForce [] = []
 intForce (h:t) = cons h $ intForce t
+--intForce (h : (!t)) = h:(intForce t)
 
 maybeForce :: Maybe t -> Maybe t
 maybeForce !Nothing = Nothing

--- a/tests/RewriteVerify/Incorrect/CoinductionIncorrect.hs
+++ b/tests/RewriteVerify/Incorrect/CoinductionIncorrect.hs
@@ -10,7 +10,6 @@ cons n (!l) = n:l
 intForce :: [Int] -> [Int]
 intForce [] = []
 intForce (h:t) = cons h $ intForce t
---intForce (h : (!t)) = h:(intForce t)
 
 maybeForce :: Maybe t -> Maybe t
 maybeForce !Nothing = Nothing
@@ -49,7 +48,6 @@ p1 = (+ 1)
 t2 :: Int -> Int
 t2 = (* 2)
 
--- TODO new example
 con :: Int -> Int
 con x = x
 

--- a/tests/RewriteVerify/Incorrect/TreeIncorrect.hs
+++ b/tests/RewriteVerify/Incorrect/TreeIncorrect.hs
@@ -47,6 +47,7 @@ bst (BBranch i t0@(BBranch j _ _) t1@(BBranch k _ _)) =
   #-}
 
 -- TODO I get SAT for this but UNSAT for forceDoesNothing
+-- for a newer verifier version, it runs forever on this instead
 {-# RULES
 "treeForceNothing" forall st . treeForce st = st
   #-}

--- a/tests/RewriteVerify/Incorrect/TreeIncorrect.hs
+++ b/tests/RewriteVerify/Incorrect/TreeIncorrect.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE BangPatterns #-}
+
+module TreeIncorrect where
+
+data SimpleTree = SLeaf
+                | SBranch SimpleTree SimpleTree
+
+treeSize :: SimpleTree -> Int
+treeSize SLeaf = 1
+treeSize (SBranch st1 st2) = 1 + (treeSize st1) + (treeSize st2)
+
+treeForce :: SimpleTree -> SimpleTree
+treeForce SLeaf = SLeaf
+treeForce (SBranch !st1 !st2) = SBranch (treeForce st1) (treeForce st2)
+
+data BTree t = BLeaf
+             | BBranch t (BTree t) (BTree t)
+
+bmap :: (a -> b) -> BTree a -> BTree b
+bmap _ BLeaf = BLeaf
+bmap f (BBranch e t1 t2) = BBranch (f e) (bmap f t1) (bmap f t2)
+
+p1 :: Int -> Int
+p1 = (+ 1)
+
+t2 :: Int -> Int
+t2 = (* 2)
+
+m1 :: Int -> Int
+m1 x = x - 1
+
+mod10 :: Int -> Int
+mod10 x = mod x 10
+
+bst :: BTree Int -> Bool
+bst BLeaf = True
+bst (BBranch i t0@(BBranch j _ _) BLeaf) = i >= j && bst t0
+bst (BBranch i BLeaf t0@(BBranch k _ _)) = i <= k && bst t0
+bst (BBranch i t0@(BBranch j _ _) t1@(BBranch k _ _)) =
+  i >= j && i <= k && bst t0 && bst t1
+
+-- TODO Z3 exhausted on bstMod; is it really invalid?
+{-# RULES
+"badSize" forall st1 st2 . treeSize (SBranch st1 st2) = 1 + (2 * treeSize st1)
+"treeMapBackward" forall bt . bmap p1 (bmap t2 bt) = bmap (t2 . p1) bt
+"bstMod" forall bt . bst (bmap mod10 bt) = bst bt
+  #-}
+
+-- TODO I get SAT for this but UNSAT for forceDoesNothing
+{-# RULES
+"treeForceNothing" forall st . treeForce st = st
+  #-}

--- a/tests/RewriteVerify/Incorrect/TreeIncorrect.hs
+++ b/tests/RewriteVerify/Incorrect/TreeIncorrect.hs
@@ -39,15 +39,12 @@ bst (BBranch i BLeaf t0@(BBranch k _ _)) = i <= k && bst t0
 bst (BBranch i t0@(BBranch j _ _) t1@(BBranch k _ _)) =
   i >= j && i <= k && bst t0 && bst t1
 
--- TODO Z3 exhausted on bstMod; is it really invalid?
 {-# RULES
 "badSize" forall st1 st2 . treeSize (SBranch st1 st2) = 1 + (2 * treeSize st1)
 "treeMapBackward" forall bt . bmap p1 (bmap t2 bt) = bmap (t2 . p1) bt
 "bstMod" forall bt . bst (bmap mod10 bt) = bst bt
   #-}
 
--- TODO I get SAT for this but UNSAT for forceDoesNothing
--- for a newer verifier version, it runs forever on this instead
 {-# RULES
 "treeForceNothing" forall st . treeForce st = st
   #-}

--- a/tests/RewriteVerify/RewriteVerifyTest.hs
+++ b/tests/RewriteVerify/RewriteVerifyTest.hs
@@ -92,7 +92,8 @@ coinduction_bad_src = "tests/RewriteVerify/Incorrect/CoinductionIncorrect.hs"
 higher_good_names :: [String]
 higher_good_names = [ "doubleMap"
                     , "mapIterate"
-                    , "mapTake" ]
+                    , "mapTake"
+                    , "mapFilter" ]
 
 higher_good_src :: String
 higher_good_src = "tests/RewriteVerify/Correct/HigherOrderCorrect.hs"

--- a/tests/RewriteVerify/RewriteVerifyTest.hs
+++ b/tests/RewriteVerify/RewriteVerifyTest.hs
@@ -74,8 +74,8 @@ coinduction_good_names = [ -- "forceIdempotent"
                            "mapTake"
                          , "takeIdempotent"
                          -- , "doubleReverse"
-                         , "doubleMap" ]
-                         -- , "mapIterate" ]
+                         , "doubleMap"
+                         , "mapIterate" ]
 
 coinduction_good_src :: String
 coinduction_good_src = "tests/RewriteVerify/Correct/CoinductionCorrect.hs"
@@ -119,7 +119,7 @@ rvTest check src rule_names = do
                             (TranslationConfig {simpl = True, load_rewrite_rules = True})
                             config
   let rules = map (findRule $ rewrite_rules bindings) rule_names
-  mapM_ (check config init_state bindings) rules
+  doTimeout (30 * length rules) mapM_ (check config init_state bindings) rules
   return ()
 
 rewriteVerifyTestsGood :: TestTree

--- a/tests/RewriteVerify/RewriteVerifyTest.hs
+++ b/tests/RewriteVerify/RewriteVerifyTest.hs
@@ -88,7 +88,7 @@ coinduction_bad_src = "tests/RewriteVerify/Incorrect/CoinductionIncorrect.hs"
 higher_good_names :: [String]
 higher_good_names = [ "doubleMap"
                     , "mapIterate"
-                    , "mapTake" ]
+                    , "mapTake"
                     , "mapFilter" ]
 
 higher_good_src :: String

--- a/tests/RewriteVerify/RewriteVerifyTest.hs
+++ b/tests/RewriteVerify/RewriteVerifyTest.hs
@@ -120,7 +120,7 @@ rvTest check src rule_names = do
                             (TranslationConfig {simpl = True, load_rewrite_rules = True})
                             config
   let rules = map (findRule $ rewrite_rules bindings) rule_names
-  doTimeout (30 * length rules) mapM_ (check config init_state bindings) rules
+  doTimeout (30 * length rules) $ mapM_ (check config init_state bindings) rules
   return ()
 
 rewriteVerifyTestsGood :: TestTree

--- a/tests/RewriteVerify/RewriteVerifyTest.hs
+++ b/tests/RewriteVerify/RewriteVerifyTest.hs
@@ -1,9 +1,5 @@
 module RewriteVerify.RewriteVerifyTest ( rewriteTests ) where
 
--- TODO
-import qualified Debug.Trace as D
--- TODO better test suite naming?
-
 import qualified Data.Map as M
 import Data.Maybe
 import qualified Data.Text as T
@@ -70,8 +66,8 @@ bad_src = "tests/RewriteVerify/Incorrect/SimpleIncorrect.hs"
 
 coinduction_good_names :: [String]
 coinduction_good_names = [ -- "forceIdempotent"
-                         -- , "dropNoRecursion"
-                           "mapTake"
+                           "dropNoRecursion"
+                         , "mapTake"
                          , "takeIdempotent"
                          -- , "doubleReverse"
                          , "doubleMap"
@@ -154,7 +150,7 @@ rewriteTests = testGroup "Rewrite Tests"
         [ rewriteVerifyTestsGood
         , rewriteVerifyTestsBad
         , coinductionTestsGood
-        -- , coinductionTestsBad
+        , coinductionTestsBad
         , higherOrderTestsGood
         , higherOrderTestsBad
         ]

--- a/tests/RewriteVerify/RewriteVerifyTest.hs
+++ b/tests/RewriteVerify/RewriteVerifyTest.hs
@@ -92,7 +92,7 @@ coinduction_bad_src = "tests/RewriteVerify/Incorrect/CoinductionIncorrect.hs"
 higher_good_names :: [String]
 higher_good_names = [ "doubleMap"
                     , "mapIterate"
-                    , "mapTake"
+                    , "mapTake" ]
                     , "mapFilter" ]
 
 higher_good_src :: String

--- a/tests/RewriteVerify/RewriteVerifyTest.hs
+++ b/tests/RewriteVerify/RewriteVerifyTest.hs
@@ -120,8 +120,10 @@ rvTest check src rule_names = do
                             (TranslationConfig {simpl = True, load_rewrite_rules = True})
                             config
   let rules = map (findRule $ rewrite_rules bindings) rule_names
-  doTimeout (30 * length rules) $ mapM_ (check config init_state bindings) rules
-  return ()
+  r <- doTimeout (30 * length rules) $ mapM_ (check config init_state bindings) rules
+  case r of
+      Nothing -> error "Timeout"
+      Just r' -> return r'
 
 rewriteVerifyTestsGood :: TestTree
 rewriteVerifyTestsGood =

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -60,17 +60,18 @@ main = do
 -- TODO commenting some out to speed up testing
 tests :: TestTree
 tests = testGroup "Tests"
-        [ sampleTests
-        , liquidTests
-        , testFileTests
-        , baseTests
-        , primTests
-        , exprTests
-        , typingTests
-        , simplificationTests
-        , ufMapQuickcheck
-        , unionFindQuickcheck
-        , rewriteTests
+        [ -- sampleTests
+        -- , liquidTests
+        -- , testFileTests
+        -- , baseTests
+        -- , primTests
+        -- , exprTests
+        -- , typingTests
+        -- , simplificationTests
+        -- , ufMapQuickcheck
+        -- , unionFindQuickcheck
+        -- , 
+        rewriteTests
         ]
 
 timeout :: Timeout

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -57,21 +57,19 @@ main = do
             ])
         (if todo then todoTests else tests)
 
--- TODO commenting some out to speed up testing
 tests :: TestTree
 tests = testGroup "Tests"
-        [ -- sampleTests
-        -- , liquidTests
-        -- , testFileTests
-        -- , baseTests
-        -- , primTests
-        -- , exprTests
-        -- , typingTests
-        -- , simplificationTests
-        -- , ufMapQuickcheck
-        -- , unionFindQuickcheck
-        -- , 
-        rewriteTests
+        [ sampleTests
+        , liquidTests
+        , testFileTests
+        , baseTests
+        , primTests
+        , exprTests
+        , typingTests
+        , simplificationTests
+        , ufMapQuickcheck
+        , unionFindQuickcheck
+        , rewriteTests
         ]
 
 timeout :: Timeout


### PR DESCRIPTION
This does not allow the equivalence checker to verify valid rewrite rules involving reverse and other strict functions.