### PR TITLE
Miscellaneous Small Fixes

### DIFF
--- a/rewritev/Main.hs
+++ b/rewritev/Main.hs
@@ -45,9 +45,11 @@ runWithArgs as = do
   proj <- guessProj src
 
   -- TODO for now, total as long as there's an extra arg
+  -- TODO finite variables
   let total = map T.pack tail_args
       m_mapsrc = mkMapSrc []
       tentry = T.pack entry
+      finite = []
 
   config <- getConfig as
 
@@ -59,7 +61,7 @@ runWithArgs as = do
       rule' = case rule of
               Just r -> r
               Nothing -> error "not found"
-  res <- checkRule config init_state bindings total rule'
+  res <- checkRule config init_state bindings total finite rule'
   print res
   return ()
 

--- a/rewritev/ZenoSuite.hs
+++ b/rewritev/ZenoSuite.hs
@@ -117,6 +117,6 @@ suite n = do
                             (TranslationConfig {simpl = True, load_rewrite_rules = True}) config
   let rule_maybes = map (\t -> find (\r -> t == ru_name r) (rewrite_rules bindings)) texts
       rules = map fromJust rule_maybes
-  res <- mapM (checkRule config init_state bindings []) rules
+  res <- mapM (checkRule config init_state bindings [] []) rules
   print $ zip rn res
   return ()

--- a/src/G2/Equiv/EquivADT.hs
+++ b/src/G2/Equiv/EquivADT.hs
@@ -86,6 +86,19 @@ exprPairing ns s1@(State {expr_env = h1}) s2@(State {expr_env = h2}) e1 e2 pairs
                   , isExprValueForm h1 e1 -> Nothing
     (Prim _ _, _) -> Just (HS.insert (Ob e1 e2) pairs)
     (_, Prim _ _) -> Just (HS.insert (Ob e1 e2) pairs)
+    -- TODO test equivalence of functions and arguments?
+    -- Might cause the verifier to miss some important things
+    -- doesn't seem to help with int-nat difference
+    -- on top of that, it breaks expNat, even with these constraints
+    {-
+    (App f1 a1, App f2 a2)
+                  | (Var i1):l1 <- unApp e1
+                  , (Var i2):l2 <- unApp e2
+                  , (idName i1) `elem` ns
+                  , (idName i2) `elem` ns
+                  , Just pairs' <- exprPairing ns s1 s2 a1 a2 pairs n1 n2 ->
+                    exprPairing ns s1 s2 f1 f2 pairs' n1 n2
+    -}
     (App _ _, _) -> Just (HS.insert (Ob e1 e2) pairs)
     (_, App _ _) -> Just (HS.insert (Ob e1 e2) pairs)
     (Lit l1, Lit l2) | l1 == l2 -> Just pairs

--- a/src/G2/Equiv/EquivADT.hs
+++ b/src/G2/Equiv/EquivADT.hs
@@ -22,7 +22,7 @@ import Data.Hashable
 
 -- the bool is True if guarded coinduction can be used
 -- TODO do I need all of these typeclasses?
-data Obligation = Ob Bool Expr Expr
+data Obligation = Ob Expr Expr
                   deriving (Show, Eq, Read, Generic, Typeable, Data)
 
 instance Hashable Obligation
@@ -34,7 +34,7 @@ proofObligations :: HS.HashSet Name ->
                     Expr ->
                     Maybe (HS.HashSet Obligation)
 proofObligations ns s1 s2 e1 e2 =
-  exprPairing ns s1 s2 e1 e2 HS.empty [] [] False
+  exprPairing ns s1 s2 e1 e2 HS.empty [] []
 
 exprPairing :: HS.HashSet Name -> -- ^ vars that should not be inlined on either side
                State t ->
@@ -44,30 +44,25 @@ exprPairing :: HS.HashSet Name -> -- ^ vars that should not be inlined on either
                HS.HashSet Obligation -> -- ^ accumulator for output obligations
                [Name] -> -- ^ variables inlined previously on the LHS
                [Name] -> -- ^ variables inlined previously on the RHS
-               Bool -> -- ^ indicates whether the exprs are immediate children of Data constructors
                Maybe (HS.HashSet Obligation)
-exprPairing ns s1@(State {expr_env = h1}) s2@(State {expr_env = h2}) e1 e2 pairs n1 n2 child =
+exprPairing ns s1@(State {expr_env = h1}) s2@(State {expr_env = h2}) e1 e2 pairs n1 n2 =
   case (e1, e2) of
     _ | e1 == e2 -> Just pairs
-    -- ignore all Ticks, pass the child value through the tick
-    (Tick _ e1', _) -> exprPairing ns s1 s2 e1' e2 pairs n1 n2 child
-    (_, Tick _ e2') -> exprPairing ns s1 s2 e1 e2' pairs n1 n2 child
-    -- TODO adjusting Var cases to avoid loops
+    -- ignore all Ticks
+    (Tick _ e1', _) -> exprPairing ns s1 s2 e1' e2 pairs n1 n2
+    (_, Tick _ e2') -> exprPairing ns s1 s2 e1 e2' pairs n1 n2
+    -- keeping track of inlined vars prevents looping
     (Var i1, Var i2) | (idName i1) `elem` n1
-                     , (idName i2) `elem` n2 -> Just (HS.insert (Ob child e1 e2) pairs)
-    -- TODO should the value of child carry over for Var recursion cases?
-    (Var i, _) | E.isSymbolic (idName i) h1 -> Just (HS.insert (Ob child e1 e2) pairs)
+                     , (idName i2) `elem` n2 -> Just (HS.insert (Ob e1 e2) pairs)
+    (Var i, _) | E.isSymbolic (idName i) h1 -> Just (HS.insert (Ob e1 e2) pairs)
                | m <- idName i
                , not $ m `elem` ns
-               , Just e <- E.lookup m h1 -> exprPairing ns s1 s2 e e2 pairs (m:n1) n2 False
-               -- TODO if e1 has a cycle of length x and e2 has one of length y,
-               -- termination will take up to xy recursive calls, with the worst
-               -- case happening if x and y are relatively prime
+               , Just e <- E.lookup m h1 -> exprPairing ns s1 s2 e e2 pairs (m:n1) n2
                | not $ (idName i) `elem` ns -> error "unmapped variable"
-    (_, Var i) | E.isSymbolic (idName i) h2 -> Just (HS.insert (Ob child e1 e2) pairs)
+    (_, Var i) | E.isSymbolic (idName i) h2 -> Just (HS.insert (Ob e1 e2) pairs)
                | m <- idName i
                , not $ m `elem` ns
-               , Just e <- E.lookup m h2 -> exprPairing ns s1 s2 e1 e pairs n1 (m:n2) False
+               , Just e <- E.lookup m h2 -> exprPairing ns s1 s2 e1 e pairs n1 (m:n2)
                | not $ (idName i) `elem` ns -> error "unmapped variable"
     -- See note in `moreRestrictive` regarding comparing DataCons
     (App _ _, App _ _)
@@ -75,7 +70,7 @@ exprPairing ns s1@(State {expr_env = h1}) s2@(State {expr_env = h2}) e1 e2 pairs
         , (Data (DataCon d2 _)):l2 <- unApp e2 ->
             if d1 == d2 then
                 let ep = uncurry (exprPairing ns s1 s2)
-                    ep' hs p = ep p hs n1 n2 True
+                    ep' hs p = ep p hs n1 n2
                     l = zip l1 l2
                 in foldM ep' pairs l
                 else Nothing
@@ -89,18 +84,16 @@ exprPairing ns s1@(State {expr_env = h1}) s2@(State {expr_env = h2}) e1 e2 pairs
                   , isExprValueForm h2 e2 -> Nothing
     (_, Prim p _) | (p == Error || p == Undefined)
                   , isExprValueForm h1 e1 -> Nothing
-    (Prim _ _, _) -> Just (HS.insert (Ob child e1 e2) pairs)
-    (_, Prim _ _) -> Just (HS.insert (Ob child e1 e2) pairs)
-    (App _ _, _) -> Just (HS.insert (Ob child e1 e2) pairs)
-    (_, App _ _) -> Just (HS.insert (Ob child e1 e2) pairs)
+    (Prim _ _, _) -> Just (HS.insert (Ob e1 e2) pairs)
+    (_, Prim _ _) -> Just (HS.insert (Ob e1 e2) pairs)
+    (App _ _, _) -> Just (HS.insert (Ob e1 e2) pairs)
+    (_, App _ _) -> Just (HS.insert (Ob e1 e2) pairs)
     (Lit l1, Lit l2) | l1 == l2 -> Just pairs
                      | otherwise -> Nothing
-    -- TODO double lambda case necessary?
-    (Lam _ _ _, Lam _ _ _) -> Just (HS.insert (Ob True e1 e2) pairs)
-    (Lam _ _ _, _) -> Just (HS.insert (Ob child e1 e2) pairs)
-    (_, Lam _ _ _) -> Just (HS.insert (Ob child e1 e2) pairs)
+    (Lam _ _ _, _) -> Just (HS.insert (Ob e1 e2) pairs)
+    (_, Lam _ _ _) -> Just (HS.insert (Ob e1 e2) pairs)
     -- assume that all types line up between the two expressions
     (Type _, Type _) -> Just pairs
-    (Case _ _ _, _) -> Just (HS.insert (Ob child e1 e2) pairs)
-    (_, Case _ _ _) -> Just (HS.insert (Ob child e1 e2) pairs)
+    (Case _ _ _, _) -> Just (HS.insert (Ob e1 e2) pairs)
+    (_, Case _ _ _) -> Just (HS.insert (Ob e1 e2) pairs)
     _ -> error $ "catch-all case\n" ++ show e1 ++ "\n" ++ show e2

--- a/src/G2/Equiv/Verifier.hs
+++ b/src/G2/Equiv/Verifier.hs
@@ -545,6 +545,8 @@ checkRule config init_state bindings total finite rule = do
       rewrite_state_r' = startingState start_equiv_tracker rewrite_state_r
   S.SomeSolver solver <- initSolver config
   putStrLn $ "***\n" ++ (show $ ru_name rule) ++ "\n***"
+  putStrLn $ show $ exprExtract rewrite_state_l
+  putStrLn $ show $ exprExtract rewrite_state_r
   res <- verifyLoop solver ns
              [(rewrite_state_l', rewrite_state_r')]
              [(rewrite_state_l', rewrite_state_r')]

--- a/src/G2/Equiv/Verifier.hs
+++ b/src/G2/Equiv/Verifier.hs
@@ -253,8 +253,10 @@ verifyLoop solver ns_pair states prev b config | not (null states) = do
 exprExtract :: State t -> Expr
 exprExtract (State { curr_expr = CurrExpr _ e }) = e
 
+-- TODO don't need guarded coinduction?
 canUseGuarded :: Obligation -> Bool
-canUseGuarded (Ob c _ _) = c
+--canUseGuarded (Ob c _ _) = c
+canUseGuarded _ = False
 
 stateWrap :: StateET -> StateET -> Obligation -> (StateET, StateET)
 stateWrap s1 s2 (Ob _ e1 e2) =

--- a/src/G2/Lib/Printers.hs
+++ b/src/G2/Lib/Printers.hs
@@ -101,6 +101,8 @@ mkExprHaskell ex = mkExprHaskell' ex 0
         mkExprHaskell' (Type _) _ = ""
         mkExprHaskell' (Cast e (_ :~ t)) i = "((coerce " ++ mkExprHaskell' e i ++ ") :: " ++ mkTypeHaskell t ++ ")"
         mkExprHaskell' (Let _ e) i = "let { ... } in " ++ mkExprHaskell' e i
+        -- TODO
+        mkExprHaskell' (Tick _ e) i = mkExprHaskell' e i
         mkExprHaskell' e _ = "e = " ++ show e ++ " NOT SUPPORTED"
 
         mkAltHaskell :: Int -> Alt -> String

--- a/tests/RewriteVerify/Correct/CoinductionCorrect.hs
+++ b/tests/RewriteVerify/Correct/CoinductionCorrect.hs
@@ -125,10 +125,19 @@ len :: [a] -> Int
 len [] = 0
 len (_:t) = 1 + len t
 
+lenDouble :: [a] -> Int
+lenDouble [] = 0
+lenDouble (_:t) = 1 + (lenDouble t) + 1
+
 -- TODO expReduced runs forever too
+-- TODO listMinus terminates, but lenDouble does not
+-- ld runs forever, but UNSAT for lpm
 {-# RULES
 "expNat" forall x xs . expLengthNat (x:xs) = S (doubleNat (expLengthNat xs))
 "expReduced" forall xs . expLength xs = (2 * expLength xs) - (expLength xs)
 "doubleMinus" forall x . idInt x = (2 * x) - x
 "listMinus" forall xs . len xs = (2 * (len xs)) - (len xs)
+"lenDouble" forall xs . lenDouble xs = (2 * (lenDouble xs)) - (lenDouble xs)
+"ld" forall xs . lenDouble xs = 1 + (lenDouble xs) - 1
+"lpm" forall xs . len xs = 1 + (len xs) - 1
   #-}

--- a/tests/RewriteVerify/Correct/CoinductionCorrect.hs
+++ b/tests/RewriteVerify/Correct/CoinductionCorrect.hs
@@ -118,6 +118,17 @@ expLengthNat :: [a] -> Nat
 expLengthNat [] = Z
 expLengthNat (_:t) = S (addNat (expLengthNat t) (expLengthNat t))
 
+idInt :: Int -> Int
+idInt x = x
+
+len :: [a] -> Int
+len [] = 0
+len (_:t) = 1 + len t
+
+-- TODO expReduced runs forever too
 {-# RULES
 "expNat" forall x xs . expLengthNat (x:xs) = S (doubleNat (expLengthNat xs))
+"expReduced" forall xs . expLength xs = (2 * expLength xs) - (expLength xs)
+"doubleMinus" forall x . idInt x = (2 * x) - x
+"listMinus" forall xs . len xs = (2 * (len xs)) - (len xs)
   #-}

--- a/tests/RewriteVerify/Correct/CoinductionCorrect.hs
+++ b/tests/RewriteVerify/Correct/CoinductionCorrect.hs
@@ -129,6 +129,10 @@ lenDouble :: [a] -> Int
 lenDouble [] = 0
 lenDouble (_:t) = 1 + (lenDouble t) + 1
 
+zeroList :: [a] -> Int
+zeroList [] = 0
+zeroList (_:t) = 0 + (zeroList t) + 0
+
 -- TODO expReduced runs forever too
 -- TODO listMinus terminates, but lenDouble does not
 -- ld runs forever, but UNSAT for lpm
@@ -140,4 +144,7 @@ lenDouble (_:t) = 1 + (lenDouble t) + 1
 "lenDouble" forall xs . lenDouble xs = (2 * (lenDouble xs)) - (lenDouble xs)
 "ld" forall xs . lenDouble xs = 1 + (lenDouble xs) - 1
 "lpm" forall xs . len xs = 1 + (len xs) - 1
+"zl" forall xs . zeroList xs = 0 + (zeroList xs) + 0
+"zl1" forall x xs . zeroList (x:xs) = zeroList xs
+"zl2" forall xs . 0 + zeroList xs + 0 = zeroList xs
   #-}

--- a/tests/RewriteVerify/Correct/CoinductionCorrect.hs
+++ b/tests/RewriteVerify/Correct/CoinductionCorrect.hs
@@ -142,6 +142,10 @@ pz x = 0 + x + 0
 -- UNSAT for zl1, runs forever on zl2
 -- UNSAT for branch2, runs forever for branch3
 -- UNSAT for branch4, branch5, branch6
+-- UNSAT for add7, add7front, add7back
+-- add7as3 runs forever
+-- branch4alt runs forever, both as a+(b+c)+d and as a+b+(c+d); not as (a+b)+c+d
+-- UNSAT for branch3alt
 {-# RULES
 "expNat" forall x xs . expLengthNat (x:xs) = S (doubleNat (expLengthNat xs))
 "expReduced" forall xs . expLength xs = (2 * expLength xs) - (expLength xs)
@@ -156,9 +160,15 @@ pz x = 0 + x + 0
 "zz" forall xs . zeroList xs = zeroList xs
 "branch2" forall xs . zeroList xs = (zeroList xs) + (zeroList xs)
 "branch3" forall xs . zeroList xs = (zeroList xs) + (zeroList xs) + (zeroList xs)
+"branch3alt" forall xs . zeroList xs = (zeroList xs) + ((zeroList xs) + (zeroList xs))
 "zeroAdd" pz 0 = pz (0 + 0 + 0 + 0 + 0)
 "b3" forall xs . zeroList xs = 0 + 0 + 0
 "branch4" forall xs . zeroList xs = (zeroList xs) + (zeroList xs) + (zeroList xs) + (zeroList xs)
+"branch4alt" forall xs . zeroList xs = (zeroList xs) + (zeroList xs) + ((zeroList xs) + (zeroList xs))
 "branch5" forall xs . zeroList xs = (zeroList xs) + (zeroList xs) + (zeroList xs) + (zeroList xs) + (zeroList xs)
 "branch6" forall xs . zeroList xs = (zeroList xs) + (zeroList xs) + (zeroList xs) + (zeroList xs) + (zeroList xs) + (zeroList xs)
+"add7" forall xs . zeroList xs = 0 + 0 + 0 + (zeroList xs) + 0 + 0 + 0
+"add7as3" forall xs . zeroList xs = (0 + 0 + 0) + (zeroList xs) + (0 + 0 + 0)
+"add7front" forall xs . zeroList xs = (((((0 + 0) + 0) + zeroList xs) + 0) + 0) + 0
+"add7back" forall xs . zeroList xs = 0 + (0 + (0 + (zeroList xs + (0 + (0 + 0)))))
   #-}

--- a/tests/RewriteVerify/Correct/CoinductionCorrect.hs
+++ b/tests/RewriteVerify/Correct/CoinductionCorrect.hs
@@ -133,9 +133,15 @@ zeroList :: [a] -> Int
 zeroList [] = 0
 zeroList (_:t) = 0 + (zeroList t) + 0
 
+pz :: Int -> Int
+pz x = 0 + x + 0
+
 -- TODO expReduced runs forever too
 -- TODO listMinus terminates, but lenDouble does not
 -- ld runs forever, but UNSAT for lpm
+-- UNSAT for zl1, runs forever on zl2
+-- UNSAT for branch2, runs forever for branch3
+-- UNSAT for branch4, branch5, branch6
 {-# RULES
 "expNat" forall x xs . expLengthNat (x:xs) = S (doubleNat (expLengthNat xs))
 "expReduced" forall xs . expLength xs = (2 * expLength xs) - (expLength xs)
@@ -146,5 +152,13 @@ zeroList (_:t) = 0 + (zeroList t) + 0
 "lpm" forall xs . len xs = 1 + (len xs) - 1
 "zl" forall xs . zeroList xs = 0 + (zeroList xs) + 0
 "zl1" forall x xs . zeroList (x:xs) = zeroList xs
-"zl2" forall xs . 0 + zeroList xs + 0 = zeroList xs
+"zl2" forall xs . pz (zeroList xs) = zeroList xs
+"zz" forall xs . zeroList xs = zeroList xs
+"branch2" forall xs . zeroList xs = (zeroList xs) + (zeroList xs)
+"branch3" forall xs . zeroList xs = (zeroList xs) + (zeroList xs) + (zeroList xs)
+"zeroAdd" pz 0 = pz (0 + 0 + 0 + 0 + 0)
+"b3" forall xs . zeroList xs = 0 + 0 + 0
+"branch4" forall xs . zeroList xs = (zeroList xs) + (zeroList xs) + (zeroList xs) + (zeroList xs)
+"branch5" forall xs . zeroList xs = (zeroList xs) + (zeroList xs) + (zeroList xs) + (zeroList xs) + (zeroList xs)
+"branch6" forall xs . zeroList xs = (zeroList xs) + (zeroList xs) + (zeroList xs) + (zeroList xs) + (zeroList xs) + (zeroList xs)
   #-}

--- a/tests/RewriteVerify/Correct/CoinductionCorrect.hs
+++ b/tests/RewriteVerify/Correct/CoinductionCorrect.hs
@@ -101,3 +101,23 @@ doubleLength (_:t) = doubleLength t + doubleLength t
 "exp" forall x xs . expLength (x:xs) = 1 + (2 * expLength xs)
 "double" forall x xs . doubleLength (x:xs) = 2 * doubleLength xs
   #-}
+
+-- TODO Nats instead of Ints
+data Nat = Z
+         | S Nat
+
+addNat :: Nat -> Nat -> Nat
+addNat Z y = y
+addNat (S x) y = S (addNat x y)
+
+doubleNat :: Nat -> Nat
+doubleNat Z = Z
+doubleNat (S x) = S (S (doubleNat x))
+
+expLengthNat :: [a] -> Nat
+expLengthNat [] = Z
+expLengthNat (_:t) = S (addNat (expLengthNat t) (expLengthNat t))
+
+{-# RULES
+"expNat" forall x xs . expLengthNat (x:xs) = S (doubleNat (expLengthNat xs))
+  #-}

--- a/tests/RewriteVerify/Correct/CoinductionCorrect.hs
+++ b/tests/RewriteVerify/Correct/CoinductionCorrect.hs
@@ -94,6 +94,7 @@ doubleLength [] = 1
 doubleLength (_:t) = doubleLength t + doubleLength t
 
 -- TODO forceConcat is actually invalid
+-- With the crHelper change in place, exp gets UNSAT.  So does double.
 {-# RULES
 "mapLength" forall f l . listLength (intMap f l) = listLength l
 "forceLength" forall l . listLength (intForce l) = listLength l
@@ -162,6 +163,8 @@ pz x = 0 + x + 0
 "branch3" forall xs . zeroList xs = (zeroList xs) + (zeroList xs) + (zeroList xs)
 "branch3alt" forall xs . zeroList xs = (zeroList xs) + ((zeroList xs) + (zeroList xs))
 "zeroAdd" pz 0 = pz (0 + 0 + 0 + 0 + 0)
+"b1" forall xs . zeroList xs = 0
+"b2" forall xs . zeroList xs = 0 + 0
 "b3" forall xs . zeroList xs = 0 + 0 + 0
 "branch4" forall xs . zeroList xs = (zeroList xs) + (zeroList xs) + (zeroList xs) + (zeroList xs)
 "branch4alt" forall xs . zeroList xs = (zeroList xs) + (zeroList xs) + ((zeroList xs) + (zeroList xs))

--- a/tests/RewriteVerify/Correct/CoinductionCorrect.hs
+++ b/tests/RewriteVerify/Correct/CoinductionCorrect.hs
@@ -134,44 +134,16 @@ zeroList :: [a] -> Int
 zeroList [] = 0
 zeroList (_:t) = 0 + (zeroList t) + 0
 
-pz :: Int -> Int
-pz x = 0 + x + 0
-
--- TODO expReduced runs forever too
--- TODO listMinus terminates, but lenDouble does not
--- ld runs forever, but UNSAT for lpm
--- UNSAT for zl1, runs forever on zl2
--- UNSAT for branch2, runs forever for branch3
--- UNSAT for branch4, branch5, branch6
--- UNSAT for add7, add7front, add7back
--- add7as3 runs forever
--- branch4alt runs forever, both as a+(b+c)+d and as a+b+(c+d); not as (a+b)+c+d
--- UNSAT for branch3alt
+-- These rules test the verifier's ability to work with primitive operations
+-- and recursion at the same time.
 {-# RULES
 "expNat" forall x xs . expLengthNat (x:xs) = S (doubleNat (expLengthNat xs))
 "expReduced" forall xs . expLength xs = (2 * expLength xs) - (expLength xs)
-"doubleMinus" forall x . idInt x = (2 * x) - x
 "listMinus" forall xs . len xs = (2 * (len xs)) - (len xs)
 "lenDouble" forall xs . lenDouble xs = (2 * (lenDouble xs)) - (lenDouble xs)
-"ld" forall xs . lenDouble xs = 1 + (lenDouble xs) - 1
-"lpm" forall xs . len xs = 1 + (len xs) - 1
-"zl" forall xs . zeroList xs = 0 + (zeroList xs) + 0
-"zl1" forall x xs . zeroList (x:xs) = zeroList xs
-"zl2" forall xs . pz (zeroList xs) = zeroList xs
-"zz" forall xs . zeroList xs = zeroList xs
 "branch2" forall xs . zeroList xs = (zeroList xs) + (zeroList xs)
 "branch3" forall xs . zeroList xs = (zeroList xs) + (zeroList xs) + (zeroList xs)
-"branch3alt" forall xs . zeroList xs = (zeroList xs) + ((zeroList xs) + (zeroList xs))
-"zeroAdd" pz 0 = pz (0 + 0 + 0 + 0 + 0)
-"b1" forall xs . zeroList xs = 0
-"b2" forall xs . zeroList xs = 0 + 0
-"b3" forall xs . zeroList xs = 0 + 0 + 0
 "branch4" forall xs . zeroList xs = (zeroList xs) + (zeroList xs) + (zeroList xs) + (zeroList xs)
-"branch4alt" forall xs . zeroList xs = (zeroList xs) + (zeroList xs) + ((zeroList xs) + (zeroList xs))
 "branch5" forall xs . zeroList xs = (zeroList xs) + (zeroList xs) + (zeroList xs) + (zeroList xs) + (zeroList xs)
 "branch6" forall xs . zeroList xs = (zeroList xs) + (zeroList xs) + (zeroList xs) + (zeroList xs) + (zeroList xs) + (zeroList xs)
-"add7" forall xs . zeroList xs = 0 + 0 + 0 + (zeroList xs) + 0 + 0 + 0
-"add7as3" forall xs . zeroList xs = (0 + 0 + 0) + (zeroList xs) + (0 + 0 + 0)
-"add7front" forall xs . zeroList xs = (((((0 + 0) + 0) + zeroList xs) + 0) + 0) + 0
-"add7back" forall xs . zeroList xs = 0 + (0 + (0 + (zeroList xs + (0 + (0 + 0)))))
   #-}

--- a/tests/RewriteVerify/Correct/TreeCorrect.hs
+++ b/tests/RewriteVerify/Correct/TreeCorrect.hs
@@ -103,7 +103,7 @@ listLeaves :: ListTree -> Int
 listLeaves (ListTree []) = 1
 listLeaves (ListTree l) = foldr (+) 0 (map listLeaves l)
 
--- TODO with the crHelper change, listLeaf gets stuck.
+-- With the crHelper change, listLeaf runs forever.
 -- The same happens without that change in place.
 {-# RULES
 "tripleLeaf" forall tt . leafCount (TBranch tt tt tt) = 3 * leafCount tt
@@ -132,6 +132,7 @@ fastFib n = case fastFibHelper [1,0] (n - 1) of
   h:_ -> h
   _ -> error "invalid input"
 
+-- Still runs forever with new conditions for induction.
 {-# RULES
 "fib" slowFib = fastFib
   #-}

--- a/tests/RewriteVerify/Correct/TreeCorrect.hs
+++ b/tests/RewriteVerify/Correct/TreeCorrect.hs
@@ -132,3 +132,40 @@ fastFib n = case fastFibHelper [1,0] (n - 1) of
 {-# RULES
 "fib" slowFib = fastFib
   #-}
+
+-- TODO testing multi-way branching issues
+data QuadTree = QLeaf
+              | QBranch QuadTree QuadTree QuadTree QuadTree
+
+quadCount :: QuadTree -> Int
+quadCount QLeaf = 1
+quadCount (QBranch a b c d) = (quadCount a) + (quadCount b) + (quadCount c) + (quadCount d)
+
+-- no extra obligations generated, runs forever
+{-# RULES
+"quadRepeat" forall qt . quadCount (QBranch qt qt qt qt) = (4 * quadCount qt)
+  #-}
+
+data PentTree = PLeaf
+              | PBranch PentTree PentTree PentTree PentTree PentTree
+
+pentCount :: PentTree -> Int
+pentCount PLeaf = 1
+pentCount (PBranch a b c d e) = (pentCount a) + (pentCount b) + (pentCount c) + (pentCount d) + (pentCount e)
+
+-- extra obligations generated, runs forever
+{-# RULES
+"pentRepeat" forall pt . pentCount (PBranch pt pt pt pt pt) = 5 * pentCount pt
+  #-}
+
+data HexTree = HLeaf
+             | HBranch HexTree HexTree HexTree HexTree HexTree HexTree
+
+hexCount :: HexTree -> Int
+hexCount HLeaf = 1
+hexCount (HBranch a b c d e f) = (hexCount a) + (hexCount b) + (hexCount c) + (hexCount d) + (hexCount e) + (hexCount f)
+
+-- extra obligations generated, runs forever
+{-# RULES
+"hexRepeat" forall ht . hexCount (HBranch ht ht ht ht ht ht) = 6 * hexCount ht
+  #-}

--- a/tests/RewriteVerify/Correct/TreeCorrect.hs
+++ b/tests/RewriteVerify/Correct/TreeCorrect.hs
@@ -81,6 +81,7 @@ posNegPath (BBranch i l r) =
 "bstTimes" forall bt . bst (bmap t2 bt) = bst bt
   #-}
 
+-- Even with the crHelper change, pnd runs forever.
 {-# RULES
 "leftMap" forall f bt . leftmost (bmap f bt) = listMap f (leftmost bt)
 "leftLength" forall bt . listLength (leftmost bt) = leftSize bt
@@ -102,6 +103,8 @@ listLeaves :: ListTree -> Int
 listLeaves (ListTree []) = 1
 listLeaves (ListTree l) = foldr (+) 0 (map listLeaves l)
 
+-- TODO with the crHelper change, listLeaf gets stuck.
+-- The same happens without that change in place.
 {-# RULES
 "tripleLeaf" forall tt . leafCount (TBranch tt tt tt) = 3 * leafCount tt
 "listLeaf" forall lt . listLeaves (ListTree [lt]) = listLeaves lt
@@ -169,3 +172,6 @@ hexCount (HBranch a b c d e f) = (hexCount a) + (hexCount b) + (hexCount c) + (h
 {-# RULES
 "hexRepeat" forall ht . hexCount (HBranch ht ht ht ht ht ht) = 6 * hexCount ht
   #-}
+
+-- With the crHelper change in place, all three of these get UNSAT.
+-- Also, seemingly, no more generation of extra obligations happens.

--- a/tests/RewriteVerify/Correct/TreeCorrect.hs
+++ b/tests/RewriteVerify/Correct/TreeCorrect.hs
@@ -7,6 +7,11 @@ treeSize :: SimpleTree -> Int
 treeSize SLeaf = 1
 treeSize (SBranch st1 st2) = (treeSize st1) + (treeSize st2)
 
+treeSizeOriginal :: SimpleTree -> Int
+treeSizeOriginal SLeaf = 1
+treeSizeOriginal (SBranch st1 st2) =
+  1 + (treeSizeOriginal st1) + (treeSizeOriginal st2)
+
 data BTree t = BLeaf
              | BBranch t (BTree t) (BTree t)
 
@@ -67,6 +72,7 @@ posNegPath (BBranch i l r) =
 
 {-# RULES
 "doubleTree" forall st . treeSize (SBranch st st) = (2 * treeSize st)
+"doubleTreeOriginal" forall st . treeSizeOriginal (SBranch st st) = 1 + (2 * treeSizeOriginal st)
 "doubleMapTree" forall bt . bmap p1 (bmap t2 bt) = bmap (p1 . t2) bt
   #-}
 

--- a/tests/RewriteVerify/Correct/Zeno.hs
+++ b/tests/RewriteVerify/Correct/Zeno.hs
@@ -835,6 +835,8 @@ forceTreeBool (Node l _ r) b = case (forceTreeBool l b) of
 
 -- TODO the theorems that don't fit the ordinary equivalence format
 {-# RULES
+"prop03" forall n xs ys . prop_03 n xs ys = True
+"prop05" forall n x xs . prop_05 n x xs = True
 "prop16" forall x xs . prop_16 x xs = True
 "prop18" forall i m . prop_18 i m = True
 "prop21" forall n m . prop_21 n m = True
@@ -852,5 +854,11 @@ forceTreeBool (Node l _ r) b = case (forceTreeBool l b) of
 "prop65" forall i m . prop_65 i m = True
 "prop66" forall p xs . prop_66 p xs = True
 "prop68" forall n xs . prop_68 n xs = True
+"prop69" forall n m . prop_69 n m = True
+"prop70" forall m n . prop_70 m n = True
+"prop71" forall x y xs . prop_71 x y xs = True
+"prop76" forall n m xs . prop_76 n m xs = True
+"prop77" forall x xs . prop_77 x xs = True
 "prop78" forall xs . prop_78 xs = True
+"prop85" forall xs ys . prop_85 xs ys = True
   #-}

--- a/tests/RewriteVerify/Correct/Zeno.hs
+++ b/tests/RewriteVerify/Correct/Zeno.hs
@@ -67,57 +67,57 @@ Z     === _     = False
 (S x) === (S y) = x === y
 
 -- adjustment to avoid void error
+{-
 (<=) :: Nat -> Nat -> Bool
 (<=) x y = case x of
   Z -> True
   S x' -> case y of
     Z -> False
     S y' -> x' <= y'
-{-
+-}
 Z     <= _     = True
 _     <= Z     = False
 (S x) <= (S y) = x <= y
--}
 
 _     < Z     = False
 Z     < _     = True
 (S x) < (S y) = x < y
 
+{-
 (+) x y = case x of
   Z -> y
   S x' -> S (x' + y)
-{-
+-}
 Z     + y = y
 (S x) + y = S (x + y)
--}
 
+{-
 (-) :: Nat -> Nat -> Nat
 (-) x y = case x of
   Z -> Z
   S x' -> case y of
     Z -> x
     S y' -> x' - y'
-{-
+-}
 Z     - _     = Z
 x     - Z     = x
 (S x) - (S y) = x - y
--}
 
 min Z     y     = Z
 min (S x) Z     = Z
 min (S x) (S y) = S (min x y)
 
+{-
 max :: Nat -> Nat -> Nat
 max x y = case x of
   Z -> y
   S x' -> case y of
     Z -> x
     S y' -> S (max x' y')
-{-
+-}
 max Z     y     = y
 max x     Z     = x
 max (S x) (S y) = S (max x y)
--}
 
 -- List functions
 
@@ -133,6 +133,7 @@ rev :: [a] -> [a]
 rev [] = []
 rev (x:xs) = rev xs ++ [x]
 
+{-
 zip :: [a] -> [b] -> [(a, b)]
 zip xs ys =
   case xs of
@@ -140,11 +141,10 @@ zip xs ys =
     x:xs' -> case ys of
       [] -> []
       y:ys' -> (x, y) : (zip xs' ys')
-{-
+-}
 zip [] _ = []
 zip _ [] = []
 zip (x:xs) (y:ys) = (x, y) : (zip xs ys)
--}
 
 delete :: Nat -> [Nat] -> [Nat]
 delete _ [] = []
@@ -164,6 +164,7 @@ elem n (x:xs) =
     True -> True
     False -> elem n xs
 
+{-
 drop :: Nat -> [a] -> [a]
 drop x xs =
   case x of
@@ -171,12 +172,12 @@ drop x xs =
     S x' -> case xs of
       [] -> []
       _:xs' -> drop x' xs'
-{-
+-}
 drop Z xs = xs
 drop _ [] = []
 drop (S x) (_:xs) = drop x xs
--}
 
+{-
 take :: Nat -> [a] -> [a]
 take x ys =
   case x of
@@ -184,11 +185,10 @@ take x ys =
     S x' -> case ys of
       [] -> []
       y:ys' -> y : (take x' ys')
-{-
+-}
 take Z _ = []
 take _ [] = []
 take (S x) (y:ys) = y : (take x ys)
--}
 
 count :: Nat -> [Nat] -> Nat
 count x [] = Z

--- a/tests/RewriteVerify/Correct/Zeno.hs
+++ b/tests/RewriteVerify/Correct/Zeno.hs
@@ -649,7 +649,6 @@ prop_85 :: Eq a => Eq b => [a] -> [b] -> Bool
 "p13" forall n x xs . drop (S n) (x : xs) = drop n xs
 "p14" forall p xs ys . filter p (xs ++ ys) = (filter p xs) ++ (filter p ys)
 "p15" forall x xs . len (ins x xs) = S (len xs)
-"prop16" forall x xs . prop_16 x xs = True
 "p17" forall n . n <= Z = n === Z
 "p19" forall n xs . len (drop n xs) = len xs - n
 "p20" forall xs . len (sort xs) = len xs
@@ -832,4 +831,26 @@ forceTreeBool (Node l _ r) b = case (forceTreeBool l b) of
 "p05b" forall n x xs . prop_05 n x xs = forceNatBool n (forceNatBool x (forceNatListBool xs True))
 "p32c" forall a b . forceNatBool a (forceNatBool b True) = (min a b === min b a)
 "p78b" forall xs . prop_78 xs = forceNatListBool xs True
+  #-}
+
+-- TODO the theorems that don't fit the ordinary equivalence format
+{-# RULES
+"prop16" forall x xs . prop_16 x xs = True
+"prop18" forall i m . prop_18 i m = True
+"prop21" forall n m . prop_21 n m = True
+"prop26" forall x xs ys . prop_26 x xs ys = True
+"prop27" forall x xs ys . prop_27 x xs ys = True
+"prop28" forall x xs . prop_28 x xs = True
+"prop29" forall x xs . prop_29 x xs = True
+"prop30" forall x xs . prop_30 x xs = True
+"prop37" forall x xs . prop_37 x xs = True
+"prop48" forall xs . prop_48 xs = True
+"prop59" forall xs ys . prop_59 xs ys = True
+"prop60" forall xs ys . prop_60 xs ys = True
+"prop62" forall xs x . prop_62 xs x = True
+"prop63" forall n xs . prop_63 n xs = True
+"prop65" forall i m . prop_65 i m = True
+"prop66" forall p xs . prop_66 p xs = True
+"prop68" forall n xs . prop_68 n xs = True
+"prop78" forall xs . prop_78 xs = True
   #-}

--- a/tests/RewriteVerify/Correct/Zeno.hs
+++ b/tests/RewriteVerify/Correct/Zeno.hs
@@ -66,15 +66,6 @@ Z     === _     = False
 (S _) === Z     = False
 (S x) === (S y) = x === y
 
--- adjustment to avoid void error
-{-
-(<=) :: Nat -> Nat -> Bool
-(<=) x y = case x of
-  Z -> True
-  S x' -> case y of
-    Z -> False
-    S y' -> x' <= y'
--}
 Z     <= _     = True
 _     <= Z     = False
 (S x) <= (S y) = x <= y
@@ -83,22 +74,9 @@ _     < Z     = False
 Z     < _     = True
 (S x) < (S y) = x < y
 
-{-
-(+) x y = case x of
-  Z -> y
-  S x' -> S (x' + y)
--}
 Z     + y = y
 (S x) + y = S (x + y)
 
-{-
-(-) :: Nat -> Nat -> Nat
-(-) x y = case x of
-  Z -> Z
-  S x' -> case y of
-    Z -> x
-    S y' -> x' - y'
--}
 Z     - _     = Z
 x     - Z     = x
 (S x) - (S y) = x - y
@@ -107,14 +85,6 @@ min Z     y     = Z
 min (S x) Z     = Z
 min (S x) (S y) = S (min x y)
 
-{-
-max :: Nat -> Nat -> Nat
-max x y = case x of
-  Z -> y
-  S x' -> case y of
-    Z -> x
-    S y' -> S (max x' y')
--}
 max Z     y     = y
 max x     Z     = x
 max (S x) (S y) = S (max x y)
@@ -133,15 +103,6 @@ rev :: [a] -> [a]
 rev [] = []
 rev (x:xs) = rev xs ++ [x]
 
-{-
-zip :: [a] -> [b] -> [(a, b)]
-zip xs ys =
-  case xs of
-    [] -> []
-    x:xs' -> case ys of
-      [] -> []
-      y:ys' -> (x, y) : (zip xs' ys')
--}
 zip [] _ = []
 zip _ [] = []
 zip (x:xs) (y:ys) = (x, y) : (zip xs ys)
@@ -164,28 +125,10 @@ elem n (x:xs) =
     True -> True
     False -> elem n xs
 
-{-
-drop :: Nat -> [a] -> [a]
-drop x xs =
-  case x of
-    Z -> xs
-    S x' -> case xs of
-      [] -> []
-      _:xs' -> drop x' xs'
--}
 drop Z xs = xs
 drop _ [] = []
 drop (S x) (_:xs) = drop x xs
 
-{-
-take :: Nat -> [a] -> [a]
-take x ys =
-  case x of
-    Z -> []
-    S x' -> case ys of
-      [] -> []
-      y:ys' -> y : (take x' ys')
--}
 take Z _ = []
 take _ [] = []
 take (S x) (y:ys) = y : (take x ys)
@@ -275,11 +218,6 @@ zipConcat _ _ [] = []
 zipConcat x xs (y:ys) = (x, y) : zip xs ys
 
 height :: Tree a -> Nat
-{-
-height a = case a of
-  Leaf -> Z
-  Node l _ r ->
--}
 height Leaf = Z
 height (Node l x r) = S (max (height l) (height r))
 

--- a/tests/RewriteVerify/RewriteVerifyTest.hs
+++ b/tests/RewriteVerify/RewriteVerifyTest.hs
@@ -28,7 +28,7 @@ findRule rule_list rule_name =
 
 acceptRule :: Config -> State t -> Bindings -> RewriteRule -> IO ()
 acceptRule config init_state bindings rule = do
-  res <- checkRule config init_state bindings [] rule
+  res <- checkRule config init_state bindings [] [] rule
   return (case res of
     S.SAT _ -> error "Satisfiable"
     S.UNSAT _ -> ()
@@ -36,7 +36,7 @@ acceptRule config init_state bindings rule = do
 
 rejectRule :: Config -> State t -> Bindings -> RewriteRule -> IO ()
 rejectRule config init_state bindings rule = do
-  res <- checkRule config init_state bindings [] rule
+  res <- checkRule config init_state bindings [] [] rule
   return (case res of
     S.SAT _ -> ()
     S.UNSAT _ -> error "Unsatisfiable"
@@ -66,7 +66,7 @@ bad_src = "tests/RewriteVerify/Incorrect/SimpleIncorrect.hs"
 
 coinduction_good_names :: [String]
 coinduction_good_names = [ "forceIdempotent"
-                           "dropNoRecursion"
+                         , "dropNoRecursion"
                          , "mapTake"
                          , "takeIdempotent"
                          , "doubleReverse"
@@ -112,6 +112,9 @@ tree_good_src = "tests/RewriteVerify/Correct/TreeCorrect.hs"
 tree_bad_names :: [String]
 tree_bad_names = [ "badSize"
                  , "treeMapBackward" ]
+
+tree_bad_src :: String
+tree_bad_src = "tests/RewriteVerify/Incorrect/TreeIncorrect.hs"
 
 -- no need for general mkMapSrc
 libs :: [String]

--- a/tests/RewriteVerify/RewriteVerifyTest.hs
+++ b/tests/RewriteVerify/RewriteVerifyTest.hs
@@ -65,11 +65,11 @@ bad_src :: String
 bad_src = "tests/RewriteVerify/Incorrect/SimpleIncorrect.hs"
 
 coinduction_good_names :: [String]
-coinduction_good_names = [ -- "forceIdempotent"
+coinduction_good_names = [ "forceIdempotent"
                            "dropNoRecursion"
                          , "mapTake"
                          , "takeIdempotent"
-                         -- , "doubleReverse"
+                         , "doubleReverse"
                          , "doubleMap"
                          , "mapIterate" ]
 
@@ -99,6 +99,19 @@ higher_bad_names = [ "direct" ]
 
 higher_bad_src :: String
 higher_bad_src = "tests/RewriteVerify/Incorrect/HigherOrderIncorrect.hs"
+
+-- TODO also add some of the tree rewrite rules
+tree_good_names :: [String]
+tree_good_names = [ "doubleTree"
+                  , "doubleTreeOriginal"
+                  , "doubleMapTree" ]
+
+tree_good_src :: String
+tree_good_src = "tests/RewriteVerify/Correct/TreeCorrect.hs"
+
+tree_bad_names :: [String]
+tree_bad_names = [ "badSize"
+                 , "treeMapBackward" ]
 
 -- no need for general mkMapSrc
 libs :: [String]
@@ -145,6 +158,14 @@ higherOrderTestsBad :: TestTree
 higherOrderTestsBad =
   testCase "HigherOrderBad" $ rvTest rejectRule higher_bad_src higher_bad_names
 
+treeTestsGood :: TestTree
+treeTestsGood =
+  testCase "TreeGood" $ rvTest acceptRule tree_good_src tree_good_names
+
+treeTestsBad :: TestTree
+treeTestsBad =
+  testCase "TreeBad" $ rvTest rejectRule tree_bad_src tree_bad_names
+
 rewriteTests :: TestTree
 rewriteTests = testGroup "Rewrite Tests"
         [ rewriteVerifyTestsGood
@@ -153,6 +174,8 @@ rewriteTests = testGroup "Rewrite Tests"
         , coinductionTestsBad
         , higherOrderTestsGood
         , higherOrderTestsBad
+        , treeTestsGood
+        , treeTestsBad
         ]
 
 


### PR DESCRIPTION
Guarded coinduction is no longer necessary, so this branch removes it.  Also, this branch fixes a problem with variable inlining in moreRestrictive:  we cannot always tag everything that's recursively defined with a "REC" tick in advance, so moreRestrictive now has a built-in guard to prevent it from inlining an individual variable more than once.  Additionally, this branch includes some framework for requiring that certain variables in a rewrite rule are finite, but the equivalence checker doesn't actually use it for anything yet.