### PR TITLE
Variable Mappings in Summary

### DIFF
--- a/src/G2/Equiv/Induction.hs
+++ b/src/G2/Equiv/Induction.hs
@@ -205,7 +205,7 @@ induction solver ns prev (s1, s2) | caseRecursion (exprExtract s1)
       let prev' = map swap prev
       ind' <- inductionL solver ns prev' (s2, s1)
       case ind' of
-        Just (s2r, imr) -> return $ Just (s1, s2r, imr)
+        Just (s2r, imr) -> return $ Just (s1, s2r, reverseIndMarker imr)
         Nothing -> return Nothing
   | otherwise = return Nothing
 

--- a/src/G2/Equiv/Summary.hs
+++ b/src/G2/Equiv/Summary.hs
@@ -10,6 +10,8 @@ import G2.Config
 
 import G2.Interface
 
+import qualified G2.Language.ExprEnv as E
+
 import Data.List
 import Data.Maybe
 
@@ -34,124 +36,185 @@ sideName :: Side -> String
 sideName ILeft = "Left"
 sideName IRight = "Right"
 
-printPG :: PrettyGuide -> StateET -> String
-printPG pg s = printHaskellPG pg s $ exprExtract s
+printPG :: PrettyGuide -> [Name] -> StateET -> String
+printPG pg ns s =
+  let h = expr_env s
+  in
+  (printHaskellPG pg s $ exprExtract s) ++
+  "\nVariables:" ++
+  (printVars pg ns s)
+
+data ChainEnd = Symbolic
+              | Cycle Id
+              | Terminal Expr
+              | Unmapped
+
+-- don't include ns names in the result here
+varsInExpr :: [Name] -> Expr -> [Id]
+varsInExpr ns e =
+  let ids = evalASTs (\e_ -> case e_ of
+                               Var i -> [i]
+                               _ -> []) e
+  in filter (\i -> not ((idName i) `elem` ns)) ids
+
+-- TODO some names could have cycles
+-- TODO right additions to inlined list?
+-- TODO need to take new bindings into account; don't display those
+-- TODO i is same as i' for symbolic
+varChain :: ExprEnv -> [Name] -> [Id] -> Id -> ([Id], ChainEnd)
+varChain h ns inlined i =
+  if i `elem` inlined then (reverse inlined, Cycle i)
+  else if (idName i) `elem` ns then (reverse inlined, Terminal $ Var i)
+  else case E.lookupConcOrSym (idName i) h of
+    Nothing -> ([], Unmapped)
+    Just (E.Sym i') -> (reverse (i':inlined), Symbolic)
+    Just (E.Conc e) -> exprChain h ns (i:inlined) e
+
+exprChain :: ExprEnv -> [Name] -> [Id] -> Expr -> ([Id], ChainEnd)
+exprChain h ns inlined e = case e of
+  Tick _ e' -> exprChain h ns inlined e'
+  Var i -> varChain h ns inlined i
+  _ -> (reverse inlined, Terminal e)
+
+-- TODO nothing for printing Names directly in Printers
+-- TODO stop inlining when something in ns reached
+-- TODO not the best case setup
+printVar :: PrettyGuide -> [Name] -> StateET -> Id -> String
+printVar pg ns s@(State{ expr_env = h }) i =
+  let (chain, c_end) = varChain h ns [] i
+      chain_strs = map (\i_ -> printHaskellPG pg s $ Var i_) chain
+      end_str = case c_end of
+        Symbolic -> "Symbolic"
+        Cycle i' -> "Cycle " ++ printHaskellPG pg s (Var i')
+        Terminal e -> printHaskellPG pg s e
+        Unmapped -> ""
+  in case c_end of
+    Unmapped -> ""
+    _ -> foldr (\s acc -> s ++ " -> " ++ acc) "" (chain_strs ++ [end_str])
+
+printVars :: PrettyGuide -> [Name] -> StateET -> String
+printVars pg ns s =
+  let vars = varsInExpr ns $ exprExtract s
+      var_strs = map (printVar pg ns s) vars
+      non_empty_strs = filter (not . null) var_strs
+  in foldr (\s acc -> acc ++ "\n" ++ s) "" $ non_empty_strs
 
 -- TODO print the name differently?
-summarizeInduction :: PrettyGuide -> IndMarker -> String
-summarizeInduction pg im@(IndMarker {
-                        ind_real_present = (s1, s2)
-                      , ind_used_present = (q1, q2)
-                      , ind_past = (p1, p2)
-                      , ind_result = (s1', s2')
-                      , ind_present_scrutinees = (e1, e2)
-                      , ind_past_scrutinees = (r1, r2)
-                      }) =
+summarizeInduction :: PrettyGuide -> [Name] -> IndMarker -> String
+summarizeInduction pg ns im@(IndMarker {
+                           ind_real_present = (s1, s2)
+                         , ind_used_present = (q1, q2)
+                         , ind_past = (p1, p2)
+                         , ind_result = (s1', s2')
+                         , ind_present_scrutinees = (e1, e2)
+                         , ind_past_scrutinees = (r1, r2)
+                         }) =
   "Induction:\n" ++
   "Real Present: " ++
   (folder_name $ track s1) ++ "," ++
   (folder_name $ track s2) ++ "\n" ++
-  (printPG pg s1) ++ "\n" ++
-  (printPG pg s2) ++ "\n" ++
+  (printPG pg ns s1) ++ "\n" ++
+  (printPG pg ns s2) ++ "\n" ++
   "Used Present: " ++
   (folder_name $ track q1) ++ "," ++
   (folder_name $ track q2) ++ "\n" ++
-  (printPG pg q1) ++ "\n" ++
-  (printPG pg q2) ++ "\n" ++
+  (printPG pg ns q1) ++ "\n" ++
+  (printPG pg ns q2) ++ "\n" ++
   "Past: " ++
   (folder_name $ track p1) ++ "," ++
   (folder_name $ track p2) ++ "\n" ++
-  (printPG pg p1) ++ "\n" ++
-  (printPG pg p2) ++ "\n" ++
+  (printPG pg ns p1) ++ "\n" ++
+  (printPG pg ns p2) ++ "\n" ++
   "Side: " ++ (sideName $ ind_side im) ++ "\n" ++
   "Result:\n" ++
-  (printPG pg s1') ++ "\n" ++
-  (printPG pg s2') ++ "\n" ++
+  (printPG pg ns s1') ++ "\n" ++
+  (printPG pg ns s2') ++ "\n" ++
   "Present Sub-Expressions Used for Induction:\n" ++
   (printHaskellPG pg q1 e1) ++ "\n" ++
   (printHaskellPG pg q2 e2) ++ "\n" ++
   "Past Sub-Expressions Used for Induction:\n" ++
-  (printPG pg r1) ++ "\n" ++
-  (printPG pg r2) ++ "\n" ++
+  (printPG pg ns r1) ++ "\n" ++
+  (printPG pg ns r2) ++ "\n" ++
   "New Variable Name: " ++ (show $ ind_fresh_name im)
 
-summarizeCoinduction :: PrettyGuide -> CoMarker -> String
-summarizeCoinduction pg (CoMarker {
-                          co_real_present = (s1, s2)
-                        , co_used_present = (q1, q2)
-                        , co_past = (p1, p2)
-                        }) =
+summarizeCoinduction :: PrettyGuide -> [Name] -> CoMarker -> String
+summarizeCoinduction pg ns (CoMarker {
+                             co_real_present = (s1, s2)
+                           , co_used_present = (q1, q2)
+                           , co_past = (p1, p2)
+                           }) =
   "Coinduction:\n" ++
   "Real Present: " ++
   (folder_name $ track s1) ++ "," ++
   (folder_name $ track s2) ++ "\n" ++
-  (printPG pg s1) ++ "\n" ++
-  (printPG pg s2) ++ "\n" ++
+  (printPG pg ns s1) ++ "\n" ++
+  (printPG pg ns s2) ++ "\n" ++
   "Used Present: " ++
   (folder_name $ track q1) ++ "," ++
   (folder_name $ track q2) ++ "\n" ++
-  (printPG pg q1) ++ "\n" ++
-  (printPG pg q2) ++ "\n" ++
+  (printPG pg ns q1) ++ "\n" ++
+  (printPG pg ns q2) ++ "\n" ++
   "Past: " ++
   (folder_name $ track p1) ++ "," ++
   (folder_name $ track p2) ++ "\n" ++
-  (printPG pg p1) ++ "\n" ++
-  (printPG pg p2)
+  (printPG pg ns p1) ++ "\n" ++
+  (printPG pg ns p2)
 
 -- TODO pretty guide type in Printers
 -- variables:  find all names used in here
 -- look them up, find a fixed point
 -- print all relevant vars beside the expressions
 -- maybe don't include definitions from the initial state
-summarizeEquality :: PrettyGuide -> EqualMarker -> String
-summarizeEquality pg (EqualMarker {
-                       eq_real_present = (s1, s2)
-                     , eq_used_present = (q1, q2)
-                     }) =
+-- TODO fixed point of inlining; don't include things in ns
+summarizeEquality :: PrettyGuide -> [Name] -> EqualMarker -> String
+summarizeEquality pg ns (EqualMarker {
+                          eq_real_present = (s1, s2)
+                        , eq_used_present = (q1, q2)
+                        }) =
   "Equivalent Expressions:\n" ++
   "Real Present: " ++
   (folder_name $ track s1) ++ ", " ++
   (folder_name $ track s2) ++ "\n" ++
-  (printPG pg s1) ++ "\n" ++
-  (printPG pg s2) ++ "\n" ++
+  (printPG pg ns s1) ++ "\n" ++
+  (printPG pg ns s2) ++ "\n" ++
   "Used States: " ++
   (folder_name $ track q1) ++ ", " ++
   (folder_name $ track q2) ++ "\n" ++
-  (printPG pg q1) ++ "\n" ++
-  (printPG pg q2)
+  (printPG pg ns q1) ++ "\n" ++
+  (printPG pg ns q2)
 
-summarizeNoObligations :: PrettyGuide -> (StateET, StateET) -> String
-summarizeNoObligations pg (s1, s2) =
+summarizeNoObligations :: PrettyGuide -> [Name] -> (StateET, StateET) -> String
+summarizeNoObligations pg ns (s1, s2) =
   "No Obligations Produced:\n" ++
   (folder_name $ track s1) ++ ", " ++
   (folder_name $ track s2) ++ "\n" ++
-  (printPG pg s1) ++ "\n" ++
-  (printPG pg s2)
+  (printPG pg ns s1) ++ "\n" ++
+  (printPG pg ns s2)
 
-summarizeNotEquivalent :: PrettyGuide -> (StateET, StateET) -> String
-summarizeNotEquivalent pg (s1, s2) =
+summarizeNotEquivalent :: PrettyGuide -> [Name] -> (StateET, StateET) -> String
+summarizeNotEquivalent pg ns (s1, s2) =
   "NOT EQUIVALENT:\n" ++
   (folder_name $ track s1) ++ ", " ++
   (folder_name $ track s2) ++ "\n" ++
-  (printPG pg s1) ++ "\n" ++
-  (printPG pg s2)
+  (printPG pg ns s1) ++ "\n" ++
+  (printPG pg ns s2)
 
-summarizeSolverFail :: PrettyGuide -> (StateET, StateET) -> String
-summarizeSolverFail pg (s1, s2) =
+summarizeSolverFail :: PrettyGuide -> [Name] -> (StateET, StateET) -> String
+summarizeSolverFail pg ns (s1, s2) =
   "SOLVER FAIL:\n" ++
   (folder_name $ track s1) ++ ", " ++
   (folder_name $ track s2) ++ "\n" ++
-  (printPG pg s1) ++ "\n" ++
-  (printPG pg s2)
+  (printPG pg ns s1) ++ "\n" ++
+  (printPG pg ns s2)
 
-summarizeAct :: PrettyGuide -> ActMarker -> String
-summarizeAct pg m = case m of
-  Induction im -> summarizeInduction pg im
-  Coinduction cm -> summarizeCoinduction pg cm
-  Equality em -> summarizeEquality pg em
-  NoObligations s_pair -> summarizeNoObligations pg s_pair
-  NotEquivalent s_pair -> summarizeNotEquivalent pg s_pair
-  SolverFail s_pair -> summarizeSolverFail pg s_pair
+summarizeAct :: PrettyGuide -> [Name] -> ActMarker -> String
+summarizeAct pg ns m = case m of
+  Induction im -> summarizeInduction pg ns im
+  Coinduction cm -> summarizeCoinduction pg ns cm
+  Equality em -> summarizeEquality pg ns em
+  NoObligations s_pair -> summarizeNoObligations pg ns s_pair
+  NotEquivalent s_pair -> summarizeNotEquivalent pg ns s_pair
+  SolverFail s_pair -> summarizeSolverFail pg ns s_pair
 
 tabsAfterNewLines :: String -> String
 tabsAfterNewLines [] = []
@@ -159,10 +222,10 @@ tabsAfterNewLines ('\n':t) = '\n':'\t':(tabsAfterNewLines t)
 tabsAfterNewLines (c:t) = c:(tabsAfterNewLines t)
 
 -- generate the guide for the whole summary externally
-summarize :: PrettyGuide -> Marker -> String
-summarize pg (Marker (sh1, sh2) m) =
+summarize :: PrettyGuide -> [Name] -> Marker -> String
+summarize pg ns (Marker (sh1, sh2) m) =
   "***\nLeft Path: " ++
   (foldr (\s acc -> acc ++ " -> " ++ s) "Start" $ map (folder_name . track) $ (latest sh1):history sh1) ++
   "\nRight Path: " ++
   (foldr (\s acc -> acc ++ " -> " ++ s) "Start" $ map (folder_name . track) $ (latest sh2):history sh2) ++ "\n" ++
-  (tabsAfterNewLines $ summarizeAct pg m)
+  (tabsAfterNewLines $ summarizeAct pg ns m)

--- a/src/G2/Equiv/Tactics.hs
+++ b/src/G2/Equiv/Tactics.hs
@@ -98,6 +98,7 @@ data ActMarker = Induction IndMarker
                | NoObligations (StateET, StateET)
                | NotEquivalent (StateET, StateET)
                | SolverFail (StateET, StateET)
+               | Unresolved (StateET, StateET)
 
 instance Named ActMarker where
   names (Induction im) = names im
@@ -106,6 +107,7 @@ instance Named ActMarker where
   names (NoObligations s_pair) = names s_pair
   names (NotEquivalent s_pair) = names s_pair
   names (SolverFail s_pair) = names s_pair
+  names (Unresolved s_pair) = names s_pair
   rename old new m = case m of
     Induction im -> Induction $ rename old new im
     Coinduction cm -> Coinduction $ rename old new cm
@@ -113,6 +115,7 @@ instance Named ActMarker where
     NoObligations s_pair -> NoObligations $ rename old new s_pair
     NotEquivalent s_pair -> NotEquivalent $ rename old new s_pair
     SolverFail s_pair -> SolverFail $ rename old new s_pair
+    Unresolved s_pair -> Unresolved $ rename old new s_pair
 
 data Marker = Marker (StateH, StateH) ActMarker
 
@@ -208,7 +211,6 @@ type Tactic s = s ->
                 (StateET, StateET) ->
                 W.WriterT [Marker] IO TacticResult
 
--- TODO not used?
 reverseCoMarker :: CoMarker -> CoMarker
 reverseCoMarker (CoMarker (s1, s2) (q1, q2) (p1, p2)) =
   CoMarker (s2, s1) (q2, q1) (p2, p1)
@@ -333,19 +335,17 @@ moreRestrictive s1@(State {expr_env = h1}) s2@(State {expr_env = h2}) ns hm n1 n
                , not $ HS.member m ns
                , not $ (m, e2) `elem` n1
                , Just e <- E.lookup m h1 ->
-                 --trace ("INLINE L " ++ show i ++ show e) $
                  moreRestrictive s1 s2 ns hm ((m, e2):n1) n2 e e2
     (_, Var i) | m <- idName i
                , not $ E.isSymbolic m h2
                , not $ HS.member m ns
                , not $ (m, e1) `elem` n2
                , Just e <- E.lookup m h2 ->
-                 --trace ("INLINE R " ++ show i ++ show e) $
                  moreRestrictive s1 s2 ns hm n1 ((m, e1):n2) e1 e
     (Var i1, Var i2) | HS.member (idName i1) ns
                      , idName i1 == idName i2 -> Just hm
-                     | HS.member (idName i1) ns -> {-trace ("VLeft " ++ show (i1, i2))-} Nothing
-                     | HS.member (idName i2) ns -> {-trace ("VRight " ++ show (i1, i2))-} Nothing
+                     | HS.member (idName i1) ns -> Nothing
+                     | HS.member (idName i2) ns -> Nothing
     (Var i, _) | E.isSymbolic (idName i) h1
                , (hm', hs) <- hm
                , Nothing <- HM.lookup i hm' -> Just (HM.insert i (inlineEquiv [] h2 ns e2) hm', hs)
@@ -353,14 +353,14 @@ moreRestrictive s1@(State {expr_env = h1}) s2@(State {expr_env = h2}) ns hm n1 n
                , Just e <- HM.lookup i (fst hm)
                , e == inlineEquiv [] h2 ns e2 -> Just hm
                -- this last case means there's a mismatch
-               | E.isSymbolic (idName i) h1 -> {-trace ("VSymLeft " ++ show i)-} Nothing
+               | E.isSymbolic (idName i) h1 -> Nothing
                | not $ (idName i, e2) `elem` n1
                , not $ HS.member (idName i) ns -> error $ "unmapped variable " ++ (show i)
-    (_, Var i) | E.isSymbolic (idName i) h2 -> {-trace ("VSymRight " ++ show i)-} Nothing -- sym replaces non-sym
+    (_, Var i) | E.isSymbolic (idName i) h2 -> Nothing -- sym replaces non-sym
                | not $ (idName i, e1) `elem` n2
                , not $ HS.member (idName i) ns -> error $ "unmapped variable " ++ (show i)
-    (App f1 a1, App f2 a2) | Just hm_f <- {-trace ("APP FN " ++ show (printHaskellDirty e1) ++ "\n" ++ show (printHaskellDirty e2))-} moreRestrictive s1 s2 ns hm n1 n2 f1 f2
-                           , Just hm_a <- {-trace ("APP ARG " ++ show hm_f ++ "\n" ++ show (printHaskellDirty a1) ++ "\n" ++ show (printHaskellDirty a2))-} moreRestrictive s1 s2 ns hm_f n1 n2 a1 a2 -> Just hm_a
+    (App f1 a1, App f2 a2) | Just hm_f <- moreRestrictive s1 s2 ns hm n1 n2 f1 f2
+                           , Just hm_a <- moreRestrictive s1 s2 ns hm_f n1 n2 a1 a2 -> Just hm_a
     -- TODO ignoring lam use; these are never used seemingly
     -- TODO shouldn't lead to non-termination
     {-

--- a/src/G2/Equiv/Verifier.hs
+++ b/src/G2/Equiv/Verifier.hs
@@ -343,6 +343,10 @@ verifyLoop solver ns states b config folder_root k n | not (null states)
   else
     return $ S.SAT ()
   | not (null states) = do
+    -- TODO log some new things with the writer for unresolved obligations
+    -- TODO the present states are somewhat redundant
+    let ob (sh1, sh2) = Marker (sh1, sh2) $ Unresolved (latest sh1, latest sh2)
+    W.tell $ map ob states
     return $ S.Unknown "Loop Iterations Exhausted"
   | otherwise = do
     return $ S.UNSAT ()

--- a/src/G2/Equiv/Verifier.hs
+++ b/src/G2/Equiv/Verifier.hs
@@ -593,7 +593,7 @@ checkRule config init_state bindings total finite print_summary iterations rule 
   if print_summary then do
     putStrLn "--- SUMMARY ---"
     let pg = mkPrettyGuide w
-    mapM (putStrLn . (summarize pg)) w
+    mapM (putStrLn . (summarize pg $ HS.toList ns)) w
     putStrLn "--- END OF SUMMARY ---"
   else return ()
   S.close solver

--- a/src/G2/Execution/Reducer.hs
+++ b/src/G2/Execution/Reducer.hs
@@ -512,7 +512,7 @@ substHigherOrder eenv m ns ce =
                                 Just e -> Just $ Id n (typeOf e)
                                 Nothing -> Nothing) $ HS.toList ns
 
-        higherOrd = filter (isTyFun . typeOf) . mapMaybe varId . symbVars eenv $ ce
+        higherOrd = filter (isTyFun . typeOf) . symbVars eenv $ ce
         higherOrdSub = map (\v -> (v, mapMaybe (genSubstitutable v) is)) higherOrd
     in
     substHigherOrder' [(eenv, m, ce)] higherOrdSub

--- a/src/G2/Language/Expr.hs
+++ b/src/G2/Language/Expr.hs
@@ -441,23 +441,22 @@ passedArgs' (App e e') = e':passedArgs' e
 passedArgs' _ = []
 
 --Returns all Vars in an ASTContainer
-vars :: (ASTContainer m Expr) => m -> [Expr]
+vars :: (ASTContainer m Expr) => m -> [Id]
 vars = evalASTs vars'
 
-vars' :: Expr -> [Expr]
-vars' v@(Var _) = [v]
+vars' :: Expr -> [Id]
+vars' (Var i) = [i]
 vars' _ = []
 
 varId :: Expr -> Maybe Id
 varId (Var i) = Just i
 varId _ = Nothing
 
-symbVars :: (ASTContainer m Expr) => ExprEnv -> m -> [Expr]
+symbVars :: (ASTContainer m Expr) => ExprEnv -> m -> [Id]
 symbVars eenv = filter (symbVars' eenv) . vars
 
-symbVars' :: ExprEnv -> Expr -> Bool
-symbVars' eenv (Var (Id n _)) = E.isSymbolic n eenv
-symbVars' _ _ = False
+symbVars' :: ExprEnv -> Id -> Bool
+symbVars' eenv (Id n _) = E.isSymbolic n eenv
 
 -- | freeVars
 -- Returns the free (unbound by a Lambda, Let, or the Expr Env) variables of an expr

--- a/src/G2/Lib/Printers.hs
+++ b/src/G2/Lib/Printers.hs
@@ -9,6 +9,7 @@ module G2.Lib.Printers ( PrettyGuide
                        , printHaskellPG
                        , mkUnsugaredExprHaskell
                        , mkTypeHaskell
+                       , mkTypeHaskellPG
                        , ppExprEnv
                        , ppRelExprEnv
                        , ppCurrExpr

--- a/src/G2/Solver/SMT2.hs
+++ b/src/G2/Solver/SMT2.hs
@@ -535,7 +535,7 @@ getLinesMatchParens' h_out n = do
 
 solveExpr :: SMTConverter con TB.Builder out io => Handle -> Handle -> con -> ExprEnv -> Expr -> IO Expr
 solveExpr h_in h_out con eenv e = do
-    let vs = symbVars eenv e
+    let vs = map (\i -> Var i) $ symbVars eenv e
     vs' <- solveExpr' h_in h_out con vs
     let vs'' = map smtastToExpr vs'
     


### PR DESCRIPTION
When an expression is displayed in the proof summary, a list of all of the expression's variable mappings is displayed along with it.  The list includes not only the variables that are in the expression itself but also the variables that are in the expressions covered by the variables' mappings, and so on until we reach a fixed point.  The mappings are displayed in "chains" that ignore some ticks.  Also, this branch adds a new ActMarker for unresolved obligations so that we can see what was left to be proven in the event that the verifier reaches the iteration limit.