### PR TITLE
Better Summarization

### DIFF
--- a/src/G2/Equiv/EquivADT.hs
+++ b/src/G2/Equiv/EquivADT.hs
@@ -50,6 +50,8 @@ unAppNoTicks e =
     e':t -> (removeTicks e'):t
     _ -> e_list
 
+-- TODO getting catch-all case from infEq with inf1 and inf2
+-- also getting two REC ticks on the variables at the beginning, which is wrong
 exprPairing :: HS.HashSet Name -> -- ^ vars that should not be inlined on either side
                State t ->
                State t ->
@@ -123,4 +125,7 @@ exprPairing ns s1@(State {expr_env = h1}) s2@(State {expr_env = h2}) e1 e2 pairs
     (Type _, Type _) -> Just pairs
     (Case _ _ _, _) -> Just (HS.insert (Ob e1 e2) pairs)
     (_, Case _ _ _) -> Just (HS.insert (Ob e1 e2) pairs)
+    -- TODO not sure if I should have it this way
+    (Var _, _) -> Just (HS.insert (Ob e1 e2) pairs)
+    (_, Var _) -> Just (HS.insert (Ob e1 e2) pairs)
     _ -> error $ "catch-all case\n" ++ show e1 ++ "\n" ++ show e2

--- a/src/G2/Equiv/EquivADT.hs
+++ b/src/G2/Equiv/EquivADT.hs
@@ -69,13 +69,13 @@ exprPairing ns s1@(State {expr_env = h1}) s2@(State {expr_env = h2}) e1 e2 pairs
     (_, Tick _ e2') -> exprPairing ns s1 s2 e1 e2' pairs n1 n2
     -- keeping track of inlined vars prevents looping
     (Var i1, Var i2) | (idName i1) `elem` n1
-                     , (idName i2) `elem` n2 -> Just (HS.insert (Ob e1 e2) pairs)
-    (Var i, _) | E.isSymbolic (idName i) h1 -> Just (HS.insert (Ob e1 e2) pairs)
+                     , (idName i2) `elem` n2 -> Just $ HS.insert (Ob e1 e2) pairs
+    (Var i, _) | E.isSymbolic (idName i) h1 -> Just $ HS.insert (Ob e1 e2) pairs
                | m <- idName i
                , not $ m `elem` ns
                , Just e <- E.lookup m h1 -> exprPairing ns s1 s2 e e2 pairs (m:n1) n2
                | not $ (idName i) `elem` ns -> error "unmapped variable"
-    (_, Var i) | E.isSymbolic (idName i) h2 -> Just (HS.insert (Ob e1 e2) pairs)
+    (_, Var i) | E.isSymbolic (idName i) h2 -> Just $ HS.insert (Ob e1 e2) pairs
                | m <- idName i
                , not $ m `elem` ns
                , Just e <- E.lookup m h2 -> exprPairing ns s1 s2 e1 e pairs n1 (m:n2)
@@ -100,8 +100,6 @@ exprPairing ns s1@(State {expr_env = h1}) s2@(State {expr_env = h2}) e1 e2 pairs
                   , isExprValueForm h2 (removeAllTicks e2) -> Nothing
     (_, Prim p _) | (p == Error || p == Undefined)
                   , isExprValueForm h1 (removeAllTicks e1) -> Nothing
-    (Prim _ _, _) -> Just (HS.insert (Ob e1 e2) pairs)
-    (_, Prim _ _) -> Just (HS.insert (Ob e1 e2) pairs)
     -- TODO test equivalence of functions and arguments?
     -- Might cause the verifier to miss some important things
     -- doesn't seem to help with int-nat difference
@@ -115,17 +113,8 @@ exprPairing ns s1@(State {expr_env = h1}) s2@(State {expr_env = h2}) e1 e2 pairs
                   , Just pairs' <- exprPairing ns s1 s2 a1 a2 pairs n1 n2 ->
                     exprPairing ns s1 s2 f1 f2 pairs' n1 n2
     -}
-    (App _ _, _) -> Just (HS.insert (Ob e1 e2) pairs)
-    (_, App _ _) -> Just (HS.insert (Ob e1 e2) pairs)
     (Lit l1, Lit l2) | l1 == l2 -> Just pairs
                      | otherwise -> Nothing
-    (Lam _ _ _, _) -> Just (HS.insert (Ob e1 e2) pairs)
-    (_, Lam _ _ _) -> Just (HS.insert (Ob e1 e2) pairs)
     -- assume that all types line up between the two expressions
     (Type _, Type _) -> Just pairs
-    (Case _ _ _, _) -> Just (HS.insert (Ob e1 e2) pairs)
-    (_, Case _ _ _) -> Just (HS.insert (Ob e1 e2) pairs)
-    -- TODO not sure if I should have it this way
-    (Var _, _) -> Just (HS.insert (Ob e1 e2) pairs)
-    (_, Var _) -> Just (HS.insert (Ob e1 e2) pairs)
-    _ -> error $ "catch-all case\n" ++ show e1 ++ "\n" ++ show e2
+    _ -> Just $ HS.insert (Ob e1 e2) pairs

--- a/src/G2/Equiv/InitRewrite.hs
+++ b/src/G2/Equiv/InitRewrite.hs
@@ -15,9 +15,9 @@ initWithRHS s b r =
            }
       b' = b { input_names = map idName $ ru_bndrs r }
   in
-  --markAndSweepPreserving emptyMemConfig s' b'
+  markAndSweepPreserving emptyMemConfig s' b'
   -- TODO temporary fix
-  (s', b')
+  --(s', b')
 
 initWithLHS :: State t -> Bindings -> RewriteRule -> (State t, Bindings)
 initWithLHS s b r =
@@ -37,6 +37,6 @@ initWithLHS s b r =
                        }
                   b' = b { input_names = map idName $ ru_bndrs r }
               in
-              --markAndSweepPreserving emptyMemConfig s' b'
+              markAndSweepPreserving emptyMemConfig s' b'
               -- TODO temporary fix
-              (s', b')
+              --(s', b')

--- a/src/G2/Equiv/InitRewrite.hs
+++ b/src/G2/Equiv/InitRewrite.hs
@@ -16,8 +16,6 @@ initWithRHS s b r =
       b' = b { input_names = map idName $ ru_bndrs r }
   in
   markAndSweepPreserving emptyMemConfig s' b'
-  -- TODO temporary fix
-  --(s', b')
 
 initWithLHS :: State t -> Bindings -> RewriteRule -> (State t, Bindings)
 initWithLHS s b r =
@@ -38,5 +36,3 @@ initWithLHS s b r =
                   b' = b { input_names = map idName $ ru_bndrs r }
               in
               markAndSweepPreserving emptyMemConfig s' b'
-              -- TODO temporary fix
-              --(s', b')

--- a/src/G2/Equiv/Summary.hs
+++ b/src/G2/Equiv/Summary.hs
@@ -16,7 +16,6 @@ import qualified G2.Language.Expr as X
 import Data.List
 import Data.Maybe
 import qualified Data.Text as DT
---import qualified Data.Strings as DS
 
 import qualified Data.HashSet as HS
 
@@ -53,14 +52,17 @@ trackName s =
     "" -> "Start"
     _ -> final_sub
 
-printPG :: PrettyGuide -> [Name] -> StateET -> String
-printPG pg ns s =
+printPG :: PrettyGuide -> [Name] -> [Id] -> StateET -> String
+printPG pg ns sym_ids s =
   let h = expr_env s
       e_str = printHaskellPG pg s $ exprExtract s
+      sym_str = printVarsList pg ns sym_ids s
+      -- TODO don't print the symbolic variables over again?
       var_str = printVars pg ns s
   in case var_str of
-    "" -> e_str ++ "\n---"
-    _ -> e_str ++ "\nVariables:\n" ++ var_str ++ "\n---"
+    "" -> e_str ++ "\nSymbolic Variables:\n" ++ sym_str ++ "\n---"
+    _ -> e_str ++ "\nSymbolic Variables:\n" ++ sym_str ++
+         "\nOther Variables:\n" ++ var_str ++ "\n---"
 
 data ChainEnd = Symbolic Id
               | Cycle Id
@@ -85,6 +87,9 @@ varsFull :: ExprEnv -> [Name] -> Expr -> [Id]
 varsFull h ns e =
   let ids = varsInExpr ns e
   in HS.toList $ varsFullRec ns h (HS.fromList ids) ids
+
+varsFullList :: ExprEnv -> [Name] -> [Id] -> [Id]
+varsFullList h ns ids = HS.toList $ varsFullRec ns h (HS.fromList ids) ids
 
 varsFullRec :: [Name] -> ExprEnv -> HS.HashSet Id -> [Id] -> HS.HashSet Id
 varsFullRec ns h seen search
@@ -128,9 +133,19 @@ printVar pg ns s@(State{ expr_env = h }) i =
     Unmapped -> ""
     _ -> (foldr (\str acc -> str ++ " -> " ++ acc) "" chain_strs) ++ end_str
 
+-- TODO use markAndSweepPreserving plus an extra filter
 printVars :: PrettyGuide -> [Name] -> StateET -> String
 printVars pg ns s =
   let vars = varsFull (expr_env s) ns (exprExtract s)
+      var_strs = map (printVar pg ns s) vars
+      non_empty_strs = filter (not . null) var_strs
+  in intercalate "\n" non_empty_strs
+
+-- TODO only need the expression environment from the state
+-- TODO redundant code
+printVarsList :: PrettyGuide -> [Name] -> [Id] -> StateET -> String
+printVarsList pg ns ids s =
+  let vars = varsFullList (expr_env s) ns ids
       var_strs = map (printVar pg ns s) vars
       non_empty_strs = filter (not . null) var_strs
   in intercalate "\n" non_empty_strs
@@ -139,18 +154,19 @@ printVars pg ns s =
 summarizeStatePairTrack :: String ->
                            PrettyGuide ->
                            [Name] ->
+                           [Id] ->
                            StateET ->
                            StateET ->
                            String
-summarizeStatePairTrack str pg ns s1 s2 =
+summarizeStatePairTrack str pg ns sym_ids s1 s2 =
   str ++ ": " ++
   (trackName s1) ++ ", " ++
   (trackName s2) ++ "\n" ++
-  (printPG pg ns s1) ++ "\n" ++
-  (printPG pg ns s2)
+  (printPG pg ns sym_ids s1) ++ "\n" ++
+  (printPG pg ns sym_ids s2)
 
-summarizeInduction :: PrettyGuide -> [Name] -> IndMarker -> String
-summarizeInduction pg ns im@(IndMarker {
+summarizeInduction :: PrettyGuide -> [Name] -> [Id] -> IndMarker -> String
+summarizeInduction pg ns sym_ids im@(IndMarker {
                            ind_real_present = (s1, s2)
                          , ind_used_present = (q1, q2)
                          , ind_past = (p1, p2)
@@ -159,79 +175,96 @@ summarizeInduction pg ns im@(IndMarker {
                          , ind_past_scrutinees = (r1, r2)
                          }) =
   "Induction:\n" ++
-  (summarizeStatePairTrack "Real Present" pg ns s1 s2) ++ "\n" ++
-  (summarizeStatePairTrack "Used Present" pg ns q1 q2) ++ "\n" ++
-  (summarizeStatePairTrack "Past" pg ns p1 p2) ++ "\n" ++
+  --(summarizeStatePairTrack "Real Present" pg ns sym_ids s1 s2) ++ "\n" ++
+  (summarizeStatePairTrack "Used Present" pg ns sym_ids q1 q2) ++ "\n" ++
+  (summarizeStatePairTrack "Past" pg ns sym_ids p1 p2) ++ "\n" ++
   "Side: " ++ (sideName $ ind_side im) ++ "\n" ++
   "Result:\n" ++
-  (printPG pg ns s1') ++ "\n" ++
-  (printPG pg ns s2') ++ "\n" ++
+  (printPG pg ns sym_ids s1') ++ "\n" ++
+  (printPG pg ns sym_ids s2') ++ "\n" ++
   "Present Sub-Expressions Used for Induction:\n" ++
   (printHaskellPG pg q1 e1) ++ "\n" ++
   (printHaskellPG pg q2 e2) ++ "\n" ++
   "Past Sub-Expressions Used for Induction:\n" ++
-  (printPG pg ns r1) ++ "\n" ++
-  (printPG pg ns r2) ++ "\n" ++
+  (printPG pg ns sym_ids r1) ++ "\n" ++
+  (printPG pg ns sym_ids r2) ++ "\n" ++
   "New Variable Name: " ++
   (printHaskellPG pg s1' $ Var $ Id (ind_fresh_name im) $ typeOf $ exprExtract s1')
 
-summarizeCoinduction :: PrettyGuide -> [Name] -> CoMarker -> String
-summarizeCoinduction pg ns (CoMarker {
+summarizeCoinduction :: PrettyGuide -> [Name] -> [Id] -> CoMarker -> String
+summarizeCoinduction pg ns sym_ids (CoMarker {
                              co_real_present = (s1, s2)
                            , co_used_present = (q1, q2)
                            , co_past = (p1, p2)
                            }) =
   "Coinduction:\n" ++
-  (summarizeStatePairTrack "Real Present" pg ns s1 s2) ++ "\n" ++
-  (summarizeStatePairTrack "Used Present" pg ns q1 q2) ++ "\n" ++
-  (summarizeStatePairTrack "Past" pg ns p1 p2)
+  --(summarizeStatePairTrack "Real Present" pg ns sym_ids s1 s2) ++ "\n" ++
+  (summarizeStatePairTrack "Used Present" pg ns sym_ids q1 q2) ++ "\n" ++
+  (summarizeStatePairTrack "Past" pg ns sym_ids p1 p2)
 
 -- variables:  find all names used in here
 -- look them up, find a fixed point
 -- print all relevant vars beside the expressions
 -- don't include definitions from the initial state (i.e. things in ns)
-summarizeEquality :: PrettyGuide -> [Name] -> EqualMarker -> String
-summarizeEquality pg ns (EqualMarker {
+summarizeEquality :: PrettyGuide -> [Name] -> [Id] -> EqualMarker -> String
+summarizeEquality pg ns sym_ids (EqualMarker {
                           eq_real_present = (s1, s2)
                         , eq_used_present = (q1, q2)
                         }) =
   "Equivalent Expressions:\n" ++
-  (summarizeStatePairTrack "Real Present" pg ns s1 s2) ++ "\n" ++
-  (summarizeStatePairTrack "Used States" pg ns q1 q2)
+  --(summarizeStatePairTrack "Real Present" pg ns sym_ids s1 s2) ++ "\n" ++
+  (summarizeStatePairTrack "Used States" pg ns sym_ids q1 q2)
 
-summarizeNoObligations :: PrettyGuide -> [Name] -> (StateET, StateET) -> String
+summarizeNoObligations :: PrettyGuide ->
+                          [Name] ->
+                          [Id] ->
+                          (StateET, StateET) ->
+                          String
 summarizeNoObligations = summarizeStatePair "No Obligations Produced"
 
-summarizeNotEquivalent :: PrettyGuide -> [Name] -> (StateET, StateET) -> String
+summarizeNotEquivalent :: PrettyGuide ->
+                          [Name] ->
+                          [Id] ->
+                          (StateET, StateET) ->
+                          String
 summarizeNotEquivalent = summarizeStatePair "NOT EQUIVALENT"
 
-summarizeSolverFail :: PrettyGuide -> [Name] -> (StateET, StateET) -> String
+summarizeSolverFail :: PrettyGuide ->
+                       [Name] ->
+                       [Id] ->
+                       (StateET, StateET) ->
+                       String
 summarizeSolverFail = summarizeStatePair "SOLVER FAIL"
 
-summarizeUnresolved :: PrettyGuide -> [Name] -> (StateET, StateET) -> String
+summarizeUnresolved :: PrettyGuide ->
+                       [Name] ->
+                       [Id] ->
+                       (StateET, StateET) ->
+                       String
 summarizeUnresolved = summarizeStatePair "Unresolved"
 
 summarizeStatePair :: String ->
                       PrettyGuide ->
                       [Name] ->
+                      [Id] ->
                       (StateET, StateET) ->
                       String
-summarizeStatePair str pg ns (s1, s2) =
+summarizeStatePair str pg ns sym_ids (s1, s2) =
   str ++ ":\n" ++
   (trackName s1) ++ ", " ++
   (trackName s2) ++ "\n" ++
-  (printPG pg ns s1) ++ "\n" ++
-  (printPG pg ns s2)
+  (printPG pg ns sym_ids s1) ++ "\n" ++
+  (printPG pg ns sym_ids s2)
 
-summarizeAct :: PrettyGuide -> [Name] -> ActMarker -> String
-summarizeAct pg ns m = case m of
-  Induction im -> summarizeInduction pg ns im
-  Coinduction cm -> summarizeCoinduction pg ns cm
-  Equality em -> summarizeEquality pg ns em
-  NoObligations s_pair -> summarizeNoObligations pg ns s_pair
-  NotEquivalent s_pair -> summarizeNotEquivalent pg ns s_pair
-  SolverFail s_pair -> summarizeSolverFail pg ns s_pair
-  Unresolved s_pair -> summarizeUnresolved pg ns s_pair
+summarizeAct :: PrettyGuide -> [Name] -> [Id] -> ActMarker -> String
+summarizeAct pg ns sym_ids m = case m of
+  Induction im -> summarizeInduction pg ns sym_ids im
+  Coinduction cm -> summarizeCoinduction pg ns sym_ids cm
+  Equality em -> summarizeEquality pg ns sym_ids em
+  NoObligations s_pair -> summarizeNoObligations pg ns sym_ids s_pair
+  NotEquivalent s_pair -> summarizeNotEquivalent pg ns sym_ids s_pair
+  SolverFail s_pair -> summarizeSolverFail pg ns sym_ids s_pair
+  Unresolved s_pair -> summarizeUnresolved pg ns sym_ids s_pair
 
 tabsAfterNewLines :: String -> String
 tabsAfterNewLines [] = []
@@ -239,8 +272,8 @@ tabsAfterNewLines ('\n':t) = '\n':'\t':(tabsAfterNewLines t)
 tabsAfterNewLines (c:t) = c:(tabsAfterNewLines t)
 
 -- generate the guide for the whole summary externally
-summarize :: PrettyGuide -> [Name] -> Marker -> String
-summarize pg ns (Marker (sh1, sh2) m) =
+summarize :: PrettyGuide -> [Name] -> [Id] -> Marker -> String
+summarize pg ns sym_ids (Marker (sh1, sh2) m) =
   let names1 = map trackName $ (latest sh1):history sh1
       names2 = map trackName $ (latest sh2):history sh2
   in
@@ -248,4 +281,4 @@ summarize pg ns (Marker (sh1, sh2) m) =
   (intercalate " -> " $ (reverse names1)) ++
   "\nRight Path: " ++
   (intercalate " -> " $ (reverse names2)) ++ "\n" ++
-  (tabsAfterNewLines $ summarizeAct pg ns m)
+  (tabsAfterNewLines $ summarizeAct pg ns sym_ids m)

--- a/src/G2/Equiv/Summary.hs
+++ b/src/G2/Equiv/Summary.hs
@@ -15,6 +15,8 @@ import qualified G2.Language.Expr as X
 
 import Data.List
 import Data.Maybe
+import qualified Data.Text as DT
+--import qualified Data.Strings as DS
 
 import qualified Data.HashSet as HS
 
@@ -42,9 +44,14 @@ sideName IRight = "Right"
 trackName :: StateET -> String
 trackName s =
   let str = folder_name $ track s
-  in case str of
+      substrs = DT.splitOn (DT.pack "/") $ DT.pack str
+      --substrs = DS.strSplitAll "/" str
+      final_sub = case reverse substrs of
+        [] -> error "No Substring"
+        fs:_ -> DT.unpack fs
+  in case final_sub of
     "" -> "Start"
-    _ -> str
+    _ -> final_sub
 
 printPG :: PrettyGuide -> [Name] -> StateET -> String
 printPG pg ns s =

--- a/src/G2/Equiv/Tactics.hs
+++ b/src/G2/Equiv/Tactics.hs
@@ -119,9 +119,16 @@ instance Named ActMarker where
 
 data Marker = Marker (StateH, StateH) ActMarker
 
+-- TODO don't need the StateH names for summary?
+-- names doesn't usually filter out duplicates
+-- TODO would be good to print concretizations of symbolic vars
+-- get symbolic ids from init state
+-- include those in the var list that you print (recursively)
+-- also no need to print real present, probably
 instance Named Marker where
   names (Marker (sh1, sh2) m) =
     names sh1 DS.>< names sh2 DS.>< names m
+    --names m
   rename old new (Marker (sh1, sh2) m) =
     Marker (rename old new sh1, rename old new sh2) $ rename old new m
 

--- a/src/G2/Equiv/Tactics.hs
+++ b/src/G2/Equiv/Tactics.hs
@@ -119,16 +119,9 @@ instance Named ActMarker where
 
 data Marker = Marker (StateH, StateH) ActMarker
 
--- TODO don't need the StateH names for summary?
--- names doesn't usually filter out duplicates
--- TODO would be good to print concretizations of symbolic vars
--- get symbolic ids from init state
--- include those in the var list that you print (recursively)
--- also no need to print real present, probably
 instance Named Marker where
   names (Marker (sh1, sh2) m) =
     names sh1 DS.>< names sh2 DS.>< names m
-    --names m
   rename old new (Marker (sh1, sh2) m) =
     Marker (rename old new sh1, rename old new sh2) $ rename old new m
 
@@ -173,7 +166,6 @@ data CoMarker = CoMarker {
   , co_past :: (StateET, StateET)
 }
 
--- TODO remove duplicates?
 instance Named CoMarker where
   names (CoMarker (s1, s2) (q1, q2) (p1, p2)) =
     foldr (DS.><) DS.empty $ map names [s1, s2, q1, q2, p1, p2]

--- a/src/G2/Equiv/Verifier.hs
+++ b/src/G2/Equiv/Verifier.hs
@@ -599,9 +599,6 @@ checkRule config init_state bindings total finite print_summary iterations rule 
   -- UNSAT for good, SAT for bad
   if print_summary then do
     putStrLn "--- SUMMARY ---"
-    -- TODO find a more concise way to make this guide in the first place
-    -- TODO get initial symbolic IDs
-    -- ru_bndrs from the rewrite rule is a list of Ids
     let pg = mkPrettyGuide $ map (\(Marker _ m) -> m) w
     mapM (putStrLn . (summarize pg (HS.toList ns) (ru_bndrs rule))) w
     putStrLn "--- END OF SUMMARY ---"

--- a/src/G2/Equiv/Verifier.hs
+++ b/src/G2/Equiv/Verifier.hs
@@ -215,7 +215,6 @@ wrapLetRec h e = modifyChildren (wrapLetRec h) e
 -- first Name is the one that maps to the Expr in the environment
 -- second Name is the one that might be wrapped
 -- do not allow wrapping for symbolic variables
--- TODO this is the culprit:  getting either 0 or 2 REC ticks
 -- modifyChildren can't see a REC tick that was just inserted above it
 wrapIfCorecursive :: G.CallGraph -> ExprEnv -> Name -> Name -> Expr -> Expr
 wrapIfCorecursive cg h n m e =
@@ -226,7 +225,7 @@ wrapIfCorecursive cg h n m e =
   then
     if E.isSymbolic m h
     then e
-    else wrcHelper m (wrapRecursiveCall m e) -- ((wrcHelper m) . (wrapRecursiveCall m)) e (wrapRecursiveCall m e)
+    else wrcHelper m (wrapRecursiveCall m e)
   else e
 
 -- the call graph must be based on the given environment
@@ -348,6 +347,7 @@ verifyLoop solver ns states b config folder_root k n | not (null states)
   | not (null states) = do
     -- TODO log some new things with the writer for unresolved obligations
     -- TODO the present states are somewhat redundant
+    W.liftIO $ putStrLn $ "Unresolved Obligations: " ++ show (length states)
     let ob (sh1, sh2) = Marker (sh1, sh2) $ Unresolved (latest sh1, latest sh2)
     W.tell $ map ob states
     return $ S.Unknown "Loop Iterations Exhausted"
@@ -599,8 +599,11 @@ checkRule config init_state bindings total finite print_summary iterations rule 
   -- UNSAT for good, SAT for bad
   if print_summary then do
     putStrLn "--- SUMMARY ---"
-    let pg = mkPrettyGuide w
-    mapM (putStrLn . (summarize pg $ HS.toList ns)) w
+    -- TODO find a more concise way to make this guide in the first place
+    -- TODO get initial symbolic IDs
+    -- ru_bndrs from the rewrite rule is a list of Ids
+    let pg = mkPrettyGuide $ map (\(Marker _ m) -> m) w
+    mapM (putStrLn . (summarize pg (HS.toList ns) (ru_bndrs rule))) w
     putStrLn "--- END OF SUMMARY ---"
   else return ()
   S.close solver


### PR DESCRIPTION
Proof summary generation is faster now.  The lists of variables that are printed for a state in the summary now show the main symbolic variables and the other variables in two different categories with no repeats.  This branch fixes some other minor issues too.