### PR TITLE
Lemma Usage in Summaries

### DIFF
--- a/src/G2/Equiv/Summary.hs
+++ b/src/G2/Equiv/Summary.hs
@@ -177,6 +177,20 @@ printMappings pg s =
   let mapping_list = HM.toList $ higher_order $ track s
   in intercalate "\n" $ map (printMapping pg) mapping_list
 
+-- TODO may need some adjustment
+-- TODO would be better to use trackName with all of these
+printLemma :: PrettyGuide -> HS.HashSet Name -> [Id] -> Lemma -> String
+printLemma pg ns sym_ids (Lemma{
+                   lemma_name = n
+                 , lemma_lhs = s1
+                 , lemma_rhs = s2
+                 , lemma_lhs_origin = n1
+                 , lemma_rhs_origin = n2
+                 }) =
+  n ++ ": from " ++
+  n1 ++ ", " ++ n2 ++ "\n" ++
+  (summarizeStatePairTrack "States" pg ns sym_ids s1 s2)
+
 -- no new line at end
 summarizeStatePairTrack :: String ->
                            PrettyGuide ->
@@ -223,11 +237,19 @@ summarizeCoinduction pg ns sym_ids (CoMarker {
                              co_real_present = (s1, s2)
                            , co_used_present = (q1, q2)
                            , co_past = (p1, p2)
+                           , lemma_used_left = lemma_l
+                           , lemma_used_right = lemma_r
                            }) =
   "Coinduction:\n" ++
   --(summarizeStatePairTrack "Real Present" pg ns sym_ids s1 s2) ++ "\n" ++
   (summarizeStatePairTrack "Used Present" pg ns sym_ids q1 q2) ++ "\n" ++
-  (summarizeStatePairTrack "Past" pg ns sym_ids p1 p2)
+  (summarizeStatePairTrack "Past" pg ns sym_ids p1 p2) ++
+  (case lemma_l of
+    Nothing -> ""
+    Just lem_l -> "\nLeft Lemma:\n" ++ printLemma pg ns sym_ids lem_l) ++
+  (case lemma_r of
+    Nothing -> ""
+    Just lem_r -> "\nRight Lemma:\n" ++ printLemma pg ns sym_ids lem_r)
 
 -- variables:  find all names used in here
 -- look them up, find a fixed point

--- a/src/G2/Equiv/Summary.hs
+++ b/src/G2/Equiv/Summary.hs
@@ -246,10 +246,14 @@ summarizeCoinduction pg ns sym_ids (CoMarker {
   (summarizeStatePairTrack "Past" pg ns sym_ids p1 p2) ++
   (case lemma_l of
     Nothing -> ""
-    Just lem_l -> "\nLeft Lemma:\n" ++ printLemma pg ns sym_ids lem_l) ++
+    Just (s1', lem_l) ->
+      "\nLeft Lemma:\n" ++ printLemma pg ns sym_ids lem_l ++
+      "\nLeft Before Lemma Usage:\n" ++ printPG pg ns sym_ids s1') ++
   (case lemma_r of
     Nothing -> ""
-    Just lem_r -> "\nRight Lemma:\n" ++ printLemma pg ns sym_ids lem_r)
+    Just (s2', lem_r) ->
+      "\nRight Lemma:\n" ++ printLemma pg ns sym_ids lem_r ++
+      "\nRight Before Lemma Usage:\n" ++ printPG pg ns sym_ids s2')
 
 -- variables:  find all names used in here
 -- look them up, find a fixed point

--- a/src/G2/Equiv/Types.hs
+++ b/src/G2/Equiv/Types.hs
@@ -127,12 +127,14 @@ data CoMarker = CoMarker {
     co_real_present :: (StateET, StateET)
   , co_used_present :: (StateET, StateET)
   , co_past :: (StateET, StateET)
+  , lemma_used_left :: Maybe Lemma
+  , lemma_used_right :: Maybe Lemma
 }
 
 instance Named CoMarker where
-  names (CoMarker (s1, s2) (q1, q2) (p1, p2)) =
-    foldr (DS.><) DS.empty $ map names [s1, s2, q1, q2, p1, p2]
-  rename old new (CoMarker (s1, s2) (q1, q2) (p1, p2)) =
+  names (CoMarker (s1, s2) (q1, q2) (p1, p2) lemma_l lemma_r) =
+    (DS.><) (names [s1, s2, q1, q2, p1, p2]) ((names lemma_l) DS.>< (names lemma_r))
+  rename old new (CoMarker (s1, s2) (q1, q2) (p1, p2) lemma_l lemma_r) =
     let r = rename old new
         s1' = r s1
         s2' = r s2
@@ -140,11 +142,13 @@ instance Named CoMarker where
         q2' = r q2
         p1' = r p1
         p2' = r p2
-    in CoMarker (s1', s2') (q1', q2') (p1', p2')
+        lemma_l' = rename old new lemma_l
+        lemma_r' = rename old new lemma_r
+    in CoMarker (s1', s2') (q1', q2') (p1', p2') lemma_l' lemma_r'
 
 reverseCoMarker :: CoMarker -> CoMarker
-reverseCoMarker (CoMarker (s1, s2) (q1, q2) (p1, p2)) =
-  CoMarker (s2, s1) (q2, q1) (p2, p1)
+reverseCoMarker (CoMarker (s1, s2) (q1, q2) (p1, p2) lemma_l lemma_r) =
+  CoMarker (s2, s1) (q2, q1) (p2, p1) lemma_r lemma_l
 
 data EqualMarker = EqualMarker {
     eq_real_present :: (StateET, StateET)
@@ -161,3 +165,28 @@ instance Named EqualMarker where
         q1' = r q1
         q2' = r q2
     in EqualMarker (s1', s2') (q1', q2')
+
+data Lemma = Lemma { lemma_name :: String
+                   , lemma_lhs :: StateET
+                   , lemma_rhs :: StateET
+                   , lemma_lhs_origin :: String
+                   , lemma_rhs_origin :: String
+                   , lemma_to_be_proven :: [(StateH, StateH)] }
+                   deriving (Eq, Generic)
+
+instance Hashable Lemma
+
+instance Named Lemma where
+  names lemma =
+    (names $ lemma_lhs lemma) DS.><
+    (names $ lemma_rhs lemma) DS.><
+    (names $ lemma_to_be_proven lemma)
+  rename old new lemma = lemma {
+      lemma_lhs = rename old new $ lemma_lhs lemma
+    , lemma_rhs = rename old new $ lemma_rhs lemma
+    , lemma_to_be_proven = rename old new $ lemma_to_be_proven lemma
+    }
+
+type ProposedLemma = Lemma
+type ProvenLemma = Lemma
+type DisprovenLemma = Lemma

--- a/src/G2/Equiv/Types.hs
+++ b/src/G2/Equiv/Types.hs
@@ -123,7 +123,7 @@ instance Named IndMarker where
     , ind_fresh_name = rename old new $ ind_fresh_name im
     }
 
--- TODO states paired with lemmas show what the state was before lemma usage
+-- states paired with lemmas show what the state was before lemma usage
 data CoMarker = CoMarker {
     co_real_present :: (StateET, StateET)
   , co_used_present :: (StateET, StateET)
@@ -178,15 +178,9 @@ data Lemma = Lemma { lemma_name :: String
 instance Hashable Lemma
 
 instance Named Lemma where
-  names lemma =
-    (names $ lemma_lhs lemma) DS.><
-    (names $ lemma_rhs lemma) DS.><
-    (names $ lemma_to_be_proven lemma)
-  rename old new lemma = lemma {
-      lemma_lhs = rename old new $ lemma_lhs lemma
-    , lemma_rhs = rename old new $ lemma_rhs lemma
-    , lemma_to_be_proven = rename old new $ lemma_to_be_proven lemma
-    }
+  names (Lemma _ s1 s2 _ _ sh) = names s1 DS.>< names s2 DS.>< names sh
+  rename old new (Lemma lnm s1 s2 f1 f2 sh) =
+    Lemma lnm (rename old new s1) (rename old new s2) f1 f2 (rename old new sh)
 
 type ProposedLemma = Lemma
 type ProvenLemma = Lemma

--- a/src/G2/Equiv/Types.hs
+++ b/src/G2/Equiv/Types.hs
@@ -123,12 +123,13 @@ instance Named IndMarker where
     , ind_fresh_name = rename old new $ ind_fresh_name im
     }
 
+-- TODO states paired with lemmas show what the state was before lemma usage
 data CoMarker = CoMarker {
     co_real_present :: (StateET, StateET)
   , co_used_present :: (StateET, StateET)
   , co_past :: (StateET, StateET)
-  , lemma_used_left :: Maybe Lemma
-  , lemma_used_right :: Maybe Lemma
+  , lemma_used_left :: Maybe (StateET, Lemma)
+  , lemma_used_right :: Maybe (StateET, Lemma)
 }
 
 instance Named CoMarker where

--- a/tests/RewriteVerify/Correct/Zeno.hs
+++ b/tests/RewriteVerify/Correct/Zeno.hs
@@ -779,6 +779,30 @@ Uncertain ones where the walking may need to be different:
 "p77fin" forall x xs . prop_77 x xs = walkList xs True
   #-}
 
+{-
+RESULTS 1/2
+No outcome seen for p72fin
+
+RESULTS 1/3
+No outcome seen for p05finD
+No outcome seen for p37finA
+No outcome seen for p39fin
+No outcome seen for p52fin
+No outcome seen for p53fin
+No outcome seen for p70finB
+No outcome seen for p76finA
+-}
+{-# RULES
+"p05finD" forall n x xs . prop_05 n x xs = walkNat x True
+"p37finA" forall x xs . prop_37 x xs = walkNatList xs True
+"p39fin" forall n x xs . count n [x] + count n xs = walkNat x (count n (x:xs))
+"p52fin" forall n xs . walkNatList xs (count n xs) = count n (rev xs)
+"p53fin" forall n xs . walkNatList xs (count n xs) = count n (sort xs)
+"p70finB" forall m n . prop_70 m n = walkNat n True
+"p72fin" forall i xs . walkList xs (rev (drop i xs)) = take (len xs - i) (rev xs)
+"p76finA" forall n m xs . prop_76 n m xs = walkNat n True
+  #-}
+
 -- TODO alternative finiteness approach
 walkNat :: Nat -> a -> a
 walkNat Z a = a

--- a/tests/RewriteVerify/Correct/Zeno.hs
+++ b/tests/RewriteVerify/Correct/Zeno.hs
@@ -793,6 +793,9 @@ TODO copied from new-theorems branch
  No outcome seen for p53fin
  No outcome seen for p70finB
  No outcome seen for p76finA
+
+ RESULTS 1/6
+ No outcome seen for p85finE after waiting for 2 minutes
  -}
 {-# RULES
 "p05finD" forall n x xs . prop_05 n x xs = walkNat x True
@@ -804,6 +807,7 @@ TODO copied from new-theorems branch
 "p72fin" forall i xs . walkList xs (rev (drop i xs)) = take (len xs - i) (rev xs)
 "p76finA" forall n m xs . prop_76 n m xs = walkNat n True
 "p85finD" forall xs ys . prop_85 xs ys = walkTwoLists (xs, ys) True
+"p85finE" forall xs ys . walkList xs (prop_85 xs ys) = walkList xs True
   #-}
 
 {-

--- a/tests/RewriteVerify/Correct/Zeno.hs
+++ b/tests/RewriteVerify/Correct/Zeno.hs
@@ -780,20 +780,6 @@ Uncertain ones where the walking may need to be different:
   #-}
 
 {-
-<<<<<<< HEAD
-RESULTS 1/2
-No outcome seen for p72fin
-
-RESULTS 1/3
-No outcome seen for p05finD
-No outcome seen for p37finA
-No outcome seen for p39fin
-No outcome seen for p52fin
-No outcome seen for p53fin
-No outcome seen for p70finB
-No outcome seen for p76finA
--}
-=======
 TODO copied from new-theorems branch
 
  RESULTS 1/2
@@ -808,7 +794,6 @@ TODO copied from new-theorems branch
  No outcome seen for p70finB
  No outcome seen for p76finA
  -}
->>>>>>> 9802f822cc05311fd8182269f0967afbe7a3d409
 {-# RULES
 "p05finD" forall n x xs . prop_05 n x xs = walkNat x True
 "p37finA" forall x xs . prop_37 x xs = walkNatList xs True
@@ -818,10 +803,9 @@ TODO copied from new-theorems branch
 "p70finB" forall m n . prop_70 m n = walkNat n True
 "p72fin" forall i xs . walkList xs (rev (drop i xs)) = take (len xs - i) (rev xs)
 "p76finA" forall n m xs . prop_76 n m xs = walkNat n True
+"p85finD" forall xs ys . prop_85 xs ys = walkTwoLists (xs, ys) True
   #-}
 
-<<<<<<< HEAD
-=======
 {-
 TODO swapped sides for p26imp, p59imp, p60imp, p62imp
 Also swapped p85imp for type issues
@@ -847,7 +831,6 @@ p85 gets stuck right after starting a2
 "p85imp" forall xs ys . (len xs =:= len ys) && (zip (rev xs) (rev ys) =:= rev (zip xs ys)) = len xs =:= len ys
   #-}
 
->>>>>>> 9802f822cc05311fd8182269f0967afbe7a3d409
 -- TODO alternative finiteness approach
 walkNat :: Nat -> a -> a
 walkNat Z a = a
@@ -856,6 +839,13 @@ walkNat (S x) a = walkNat x a
 walkList :: [a] -> b -> b
 walkList [] a = a
 walkList (_:xs) a = walkList xs a
+
+-- TODO new walking functions for more complex situations
+walkTwoLists :: ([a], [b]) -> c -> c
+walkTwoLists ([], []) a = a
+walkTwoLists ([], ys) a = walkList ys a
+walkTwoLists (xs, []) a = walkList xs a
+walkTwoLists (x:xs, y:ys) a = walkTwoLists (xs, ys) a
 
 walkNatList :: [Nat] -> a -> a
 walkNatList xs a = case xs of

--- a/tests/scripts/zenoverify.py
+++ b/tests/scripts/zenoverify.py
@@ -34,7 +34,7 @@ def call_zeno_process(thm, var_settings, time):
 equivalences = [
     "p01",
     "p02",
-    "p03",
+    # "p03",
     "p04",
     "p06",
     "p07",
@@ -97,7 +97,7 @@ equivalences = [
 equivalences_all_total = [
     ("p01", ["n", "xs"]),
     ("p02", ["n", "xs", "ys"]),
-    ("p03", ["n", "xs", "ys"]),
+    # ("p03", ["n", "xs", "ys"]),
     ("p04", ["n", "xs"]),
     ("p09", ["i", "j", "k"]),
     ("p11", ["xs"]),


### PR DESCRIPTION
If a use of coinduction involves a lemma, the CoMarker for that use of coinduction will now give information about that lemma.  This branch also includes some reorganization of the types that the verifier uses.