### PR TITLE
Sound Matching for Total Expressions

### DIFF
--- a/src/G2/Equiv/G2Calls.hs
+++ b/src/G2/Equiv/G2Calls.hs
@@ -247,10 +247,10 @@ instance Reducer EquivReducer () EquivTracker where
                         -- unApp, make sure every arg is a total symbolic var
                         -- these are exprs originally
                         es = map exprVarName $ unApp e'
-                        all_vars = foldr (&&) True $ map isJust es
+                        all_vars = all isJust es
                         es' = map (\(Just n) -> n) $ filter isJust es
-                        all_sym = foldr (&&) True $ map (\x -> E.isSymbolic x eenv) es'
-                        all_total = foldr (&&) True $ map (`elem` total) es'
+                        all_sym = all (\x -> E.isSymbolic x eenv) es'
+                        all_total = all (`elem` total) es'
                         total' = if all_vars && all_sym && all_total
                                  then HS.insert (idName v) total
                                  else total

--- a/src/G2/Equiv/Tactics.hs
+++ b/src/G2/Equiv/Tactics.hs
@@ -35,7 +35,6 @@ module G2.Equiv.Tactics
     , insertDisprovenLemma
 
     , mkProposedLemma
-    , transferTrackerInfo
     )
     where
 
@@ -413,7 +412,7 @@ validMap s1 s2 hm =
   in all check hm_list
 
 -- TODO not exhaustive
--- TODO do cyclic expressions count as total?  I think so
+-- cyclic expressions count as total
 totalExpr :: StateET ->
              HS.HashSet Name ->
              [Name] -> -- variables inlined previously
@@ -815,19 +814,6 @@ equivLemma solver ns (Lemma { lemma_lhs = l1_1, lemma_rhs = l1_2 }) lems = do
                     case (mr1, mr2) of
                         (Right _, Right _) -> return True
                         _ -> return False) lems
-
--- Don't share expr env and path constraints between sides
--- info goes from left to right
-transferTrackerInfo :: StateET -> StateET -> StateET
-transferTrackerInfo s1 s2 =
-  let t1 = track s1
-      t2 = track s2
-      t2' = t2 {
-        higher_order = higher_order t1
-      , total = total t1
-      , finite = finite t1
-      }
-  in s2 { track = t2' }
 
 -- TODO: Does substLemma need to do something more to check correctness of path constraints?
 -- `substLemma state lemmas` tries to apply each proven lemma in `lemmas` to `state`.

--- a/src/G2/Equiv/Verifier.hs
+++ b/src/G2/Equiv/Verifier.hs
@@ -135,6 +135,19 @@ pathCondsConsistent solver (s1, s2) = do
     S.UNSAT () -> return False
     _ -> return True
 
+-- Don't share expr env and path constraints between sides
+-- info goes from left to right
+transferTrackerInfo :: StateET -> StateET -> StateET
+transferTrackerInfo s1 s2 =
+  let t1 = track s1
+      t2 = track s2
+      t2' = t2 {
+        higher_order = higher_order t1
+      , total = total t1
+      , finite = finite t1
+      }
+  in s2 { track = t2' }
+
 frameWrap :: Frame -> Expr -> Expr
 frameWrap (CaseFrame i alts) e = Case e i alts
 frameWrap (ApplyFrame e') e = App e e'

--- a/src/G2/Equiv/Verifier.hs
+++ b/src/G2/Equiv/Verifier.hs
@@ -135,19 +135,6 @@ pathCondsConsistent solver (s1, s2) = do
     S.UNSAT () -> return False
     _ -> return True
 
--- Don't share expr env and path constraints between sides
--- info goes from left to right
-transferTrackerInfo :: StateET -> StateET -> StateET
-transferTrackerInfo s1 s2 =
-  let t1 = track s1
-      t2 = track s2
-      t2' = t2 {
-        higher_order = higher_order t1
-      , total = total t1
-      , finite = finite t1
-      }
-  in s2 { track = t2' }
-
 frameWrap :: Frame -> Expr -> Expr
 frameWrap (CaseFrame i alts) e = Case e i alts
 frameWrap (ApplyFrame e') e = App e e'

--- a/tests/scripts/zenoverify.py
+++ b/tests/scripts/zenoverify.py
@@ -258,7 +258,7 @@ old_successes = [
     ("p12", []),
     ("p13", []),
     ("p14", []),
-    ("p16finA", [xs]), # slow
+    ("p16finA", [xs]), # extra slow, took about 2:10
     ("p17", []),
     ("p18fin", []),
     ("p19", [n]),

--- a/tests/scripts/zenoverify.py
+++ b/tests/scripts/zenoverify.py
@@ -345,11 +345,12 @@ def test_suite_fail(suite, timeout = 25):
     print(sat_num, "Confirmed out of", len(suite))
 
 def main():
-    test_suite_simple(custom_finite)
-    test_suite(equivalences_all_total)
-    test_suite(finite_long, 120)
-    test_suite_fail(equivalences_should_fail)
+    #test_suite_simple(custom_finite)
+    #test_suite(equivalences_all_total)
+    #test_suite(finite_long, 120)
+    #test_suite_fail(equivalences_should_fail)
     #test_suite(more_finite)
+    test_suite(old_successes, 120)
 
 if __name__ == "__main__":
     main()

--- a/tests/scripts/zenoverify.py
+++ b/tests/scripts/zenoverify.py
@@ -345,12 +345,12 @@ def test_suite_fail(suite, timeout = 25):
     print(sat_num, "Confirmed out of", len(suite))
 
 def main():
-    #test_suite_simple(custom_finite)
-    #test_suite(equivalences_all_total)
-    #test_suite(finite_long, 120)
-    #test_suite_fail(equivalences_should_fail)
+    test_suite_simple(custom_finite)
+    test_suite(equivalences_all_total)
+    test_suite(finite_long, 120)
+    test_suite_fail(equivalences_should_fail)
     #test_suite(more_finite)
-    test_suite(old_successes, 120)
+    #test_suite(old_successes, 150)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
A mapping created by moreRestrictive is not valid if it maps a total symbolic variable to a non-total expression.