### PR TITLE
Faster State Synchronization

### DIFF
--- a/src/G2/Equiv/G2Calls.hs
+++ b/src/G2/Equiv/G2Calls.hs
@@ -274,7 +274,6 @@ instance Reducer EquivReducer () EquivTracker where
 -- cyclic expressions do not count as total for now
 -- if a cycle never goes through a Data constructor, it's not total
 -- TODO reject Error and Undefined primitives
--- TODO move lookup and symbolic helpers in here
 totalExpr :: StateET ->
              HS.HashSet Name ->
              [Name] -> -- variables inlined previously
@@ -291,9 +290,7 @@ totalExpr s@(State { expr_env = h, track = EquivTracker _ _ total _ _ h' _ }) ns
           , Just e' <- lookupBoth m h h' -> totalExpr s ns (m:n) e'
           | (idName i) `elem` n -> False
           | HS.member (idName i) ns -> False
-          -- TODO make a version that can see the other expr env
-          | otherwise -> False
-          -- | otherwise -> error $ "unmapped variable " ++ show i ++ " " ++ (folder_name $ track s)
+          | otherwise -> error $ "unmapped variable " ++ show i ++ " " ++ (folder_name $ track s)
     App f a -> totalExpr s ns n f && totalExpr s ns n a
     Data _ -> True
     Prim p _ -> not (p == Error || p == Undefined)

--- a/src/G2/Equiv/G2Calls.hs
+++ b/src/G2/Equiv/G2Calls.hs
@@ -288,7 +288,9 @@ totalExpr s@(State { expr_env = h, track = EquivTracker _ _ total _ _ _ }) ns n 
           , Just e' <- E.lookup m h -> totalExpr s ns (m:n) e'
           | (idName i) `elem` n -> False
           | HS.member (idName i) ns -> False
-          | otherwise -> error $ "unmapped variable " ++ show i ++ " " ++ (folder_name $ track s)
+          -- TODO make a version that can see the other expr env
+          | otherwise -> False
+          -- | otherwise -> error $ "unmapped variable " ++ show i ++ " " ++ (folder_name $ track s)
     App f a -> totalExpr s ns n f && totalExpr s ns n a
     Data _ -> True
     Prim p _ -> not (p == Error || p == Undefined)

--- a/src/G2/Equiv/G2Calls.hs
+++ b/src/G2/Equiv/G2Calls.hs
@@ -95,7 +95,7 @@ instance Reducer SymbolicSwapper () EquivTracker where
     redRules r@(SymbolicSwapper h_opp track_opp) rv
                   s@(State { curr_expr = CurrExpr _ e
                            , expr_env = h
-                           , track = EquivTracker et m tot fin dcp fname })
+                           , track = EquivTracker et m tot fin dcp opp fname })
                   b =
         case e of
             Var i@(Id n _) | E.isSymbolic n h ->
@@ -107,7 +107,7 @@ instance Reducer SymbolicSwapper () EquivTracker where
                             h' = foldr (\j -> E.insertSymbolic j) (E.insert n e' h) (L.nub vi)
                             total' = HS.union (HS.intersection (total track_opp) vi_hs) tot
                             finite' = HS.union (HS.intersection (finite track_opp) vi_hs) fin
-                            track' = EquivTracker et m total' finite' dcp fname
+                            track' = EquivTracker et m total' finite' dcp opp fname
                             s' = s {
                               expr_env = h'
                             , track = track'
@@ -124,9 +124,9 @@ instance Reducer EnforceProgressR () EquivTracker where
     initReducer _ _ = ()
     redRules r rv s@(State { curr_expr = CurrExpr _ e
                            , num_steps = n
-                           , track = EquivTracker et m total finite dcp fname })
+                           , track = EquivTracker et m total finite dcp opp fname })
                   b =
-        let s' = s { track = EquivTracker et (Just n) total finite dcp fname }
+        let s' = s { track = EquivTracker et (Just n) total finite dcp opp fname }
         in
         case (e, m) of
             (Tick (NamedLoc (Name p _ _ _)) _, Nothing) ->
@@ -198,7 +198,7 @@ instance Halter EnforceProgressH () EquivTracker where
     stopRed _ _ _ s =
         let CurrExpr _ e = curr_expr s
             n' = num_steps s
-            EquivTracker _ m _ _ _ _ = track s
+            EquivTracker _ m _ _ _ _ _ = track s
             h = expr_env s
         in
         case m of
@@ -213,7 +213,7 @@ instance Halter EnforceProgressH () EquivTracker where
     stepHalter _ _ _ _ _ = ()
 
 emptyEquivTracker :: EquivTracker
-emptyEquivTracker = EquivTracker HM.empty Nothing HS.empty HS.empty [] ""
+emptyEquivTracker = EquivTracker HM.empty Nothing HS.empty HS.empty [] E.empty ""
 
 data EquivReducer = EquivReducer
 
@@ -222,7 +222,7 @@ instance Reducer EquivReducer () EquivTracker where
     redRules r _
                  s@(State { expr_env = eenv
                           , curr_expr = CurrExpr Evaluate e
-                          , track = EquivTracker et m total finite dcp fname })
+                          , track = EquivTracker et m total finite dcp opp fname })
                  b@(Bindings { name_gen = ng })
         | isSymFuncApp eenv (removeAllTicks e) =
             let
@@ -261,7 +261,7 @@ instance Reducer EquivReducer () EquivTracker where
                                  then HS.insert (idName v) total
                                  else total
                         s' = s { curr_expr = CurrExpr Evaluate (Var v)
-                               , track = EquivTracker et' m total' finite dcp fname
+                               , track = EquivTracker et' m total' finite dcp opp fname
                                , expr_env = E.insertSymbolic v eenv }
                         b' = b { name_gen = ng' }
                     in-- trace ("SYM FUNC " ++ show v ++ "\n" ++ show e) $
@@ -277,7 +277,7 @@ totalExpr :: StateET ->
              [Name] -> -- variables inlined previously
              Expr ->
              Bool
-totalExpr s@(State { expr_env = h, track = EquivTracker _ _ total _ _ _ }) ns n e =
+totalExpr s@(State { expr_env = h, track = EquivTracker _ _ total _ _ _ _ }) ns n e =
   case e of
     Tick _ e' -> totalExpr s ns n e'
     Var i | m <- idName i
@@ -334,22 +334,23 @@ inlineVars' seen eenv (App e1 e2) = App (inlineVars' seen eenv e1) (inlineVars' 
 inlineVars' _ _ e = e
 
 instance ASTContainer EquivTracker Expr where
-    containedASTs (EquivTracker hm _ _ _ _ _) = HM.keys hm
-    modifyContainedASTs f (EquivTracker hm m total finite dcp fname) =
+    containedASTs (EquivTracker hm _ _ _ _ _ _) = HM.keys hm
+    modifyContainedASTs f (EquivTracker hm m total finite dcp opp fname) =
         (EquivTracker . HM.fromList . map (\(k, v) -> (f k, v)) $ HM.toList hm)
-        m total finite dcp fname
+        m total finite dcp opp fname
 
 instance ASTContainer EquivTracker Type where
-    containedASTs (EquivTracker hm _ _ _ _ _) = containedASTs $ HM.keys hm
-    modifyContainedASTs f (EquivTracker hm m total finite dcp fname) =
+    containedASTs (EquivTracker hm _ _ _ _ _ _) = containedASTs $ HM.keys hm
+    modifyContainedASTs f (EquivTracker hm m total finite dcp opp fname) =
         ( EquivTracker
         . HM.fromList
         . map (\(k, v) -> (modifyContainedASTs f k, modifyContainedASTs f v))
         $ HM.toList hm )
-        m total finite dcp fname
+        m total finite dcp opp fname
 
 -- TODO should names change in total and finite?
+-- TODO change names for dc path?
 instance Named EquivTracker where
-    names (EquivTracker hm _ _ _ _ _) = names hm
-    rename old new (EquivTracker hm m total finite dcp fname) =
-        EquivTracker (rename old new hm) m (rename old new total) (rename old new finite) dcp fname
+    names (EquivTracker hm _ _ _ _ _ _) = names hm
+    rename old new (EquivTracker hm m total finite dcp opp fname) =
+        EquivTracker (rename old new hm) m (rename old new total) (rename old new finite) dcp (rename old new opp) fname

--- a/src/G2/Equiv/Induction.hs
+++ b/src/G2/Equiv/Induction.hs
@@ -397,6 +397,6 @@ generalizeFull solver ns _ (fresh_name:_) sh_pair s_pair = do
   gfold <- generalizeFold solver ns fresh_name sh_pair s_pair
   case gfold of
     Nothing -> return $ NoProof []
-    Just (s1, s2, q1, q2) -> let lem = trace ("GEN " ++ (folder_name $ track q1) ++ " " ++ (folder_name $ track q2)) mkProposedLemma "Generalization" s1 s2 q1 q2
+    Just (s1, s2, q1, q2) -> let lem = mkProposedLemma "Generalization" s1 s2 q1 q2
                              in return $ NoProof $ [lem]
 generalizeFull _ _ _ _ _ _ = return $ NoProof []

--- a/src/G2/Equiv/Induction.hs
+++ b/src/G2/Equiv/Induction.hs
@@ -397,6 +397,6 @@ generalizeFull solver ns _ (fresh_name:_) sh_pair s_pair = do
   gfold <- generalizeFold solver ns fresh_name sh_pair s_pair
   case gfold of
     Nothing -> return $ NoProof []
-    Just (s1, s2, q1, q2) -> let lem = mkProposedLemma "Generalization" s1 s2 q1 q2
+    Just (s1, s2, q1, q2) -> let lem = trace ("GEN " ++ (folder_name $ track q1) ++ " " ++ (folder_name $ track q2)) mkProposedLemma "Generalization" s1 s2 q1 q2
                              in return $ NoProof $ [lem]
 generalizeFull _ _ _ _ _ _ = return $ NoProof []

--- a/src/G2/Equiv/Tactics.hs
+++ b/src/G2/Equiv/Tactics.hs
@@ -832,9 +832,9 @@ coinductionFoldL :: S.Solver solver =>
                     (StateET, StateET) ->
                     W.WriterT [Marker] IO (Either [Lemma] (Maybe (StateET, Lemma), Maybe (StateET, Lemma), PrevMatch EquivTracker))
 coinductionFoldL solver ns lemmas gen_lemmas (sh1, sh2) (s1, s2) = do
-  --let prev = prevFull (sh1, sh2)
+  let prev = prevFull (sh1, sh2)
   -- TODO reworking parts to keep state pairs with each other
-  let prev = zip (history sh1) (history sh2)
+  --let prev = zip (history sh1) (history sh2)
   -- TODO this function not used outside coinduction
   res <- moreRestrictivePairWithLemmasOnFuncApps solver validCoinduction ns lemmas prev (s1', s2')
   case res of

--- a/src/G2/Equiv/Tactics.hs
+++ b/src/G2/Equiv/Tactics.hs
@@ -708,9 +708,6 @@ moreRestrictiveSingle :: S.Solver solver =>
                          StateET ->
                          W.WriterT [Marker] IO (Either (Maybe Lemma) (HM.HashMap Id Expr))
 moreRestrictiveSingle solver ns s1 s2 = do
-    let fs10 = Name "fs?" Nothing 21293 Nothing
-    W.liftIO $ putStrLn $ show (folder_name $ track s1, folder_name $ track s2)
-    W.liftIO $ putStrLn $ show (lookupBoth fs10 (expr_env s1) (opp_env $ track s1))
     case restrictHelper s1 s2 ns $ Right (HM.empty, HS.empty) of
         (Left l) -> return $ Left l
         Right (hm, obs) -> do

--- a/src/G2/Equiv/Tactics.hs
+++ b/src/G2/Equiv/Tactics.hs
@@ -179,7 +179,7 @@ moreRestrictivePC solver s1 s2 hm = do
     S.UNSAT () -> return True
     _ -> return False
 
--- TODO helper function to circumvent syncSymbolic
+-- helper function to circumvent syncSymbolic
 -- for symbolic things, lookup returns the variable
 lookupBoth :: Name -> ExprEnv -> ExprEnv -> Maybe Expr
 lookupBoth n h1 h2 = case E.lookupConcOrSym n h1 of
@@ -551,14 +551,6 @@ syncSymbolic s1 s2 =
   let et1 = (track s1) { opp_env = expr_env s2 }
       et2 = (track s2) { opp_env = expr_env s1 }
   in (s1 { track = et1 }, s2 { track = et2 })
-{-
-  let f (E.SymbObj _) e2 = e2
-      f e1 _ = e1
-      h1 = E.unionWith f (expr_env s1) (expr_env s2)
-      -- TODO I don't think we really need two separate unions
-      h2 = E.unionWith f (expr_env s2) (expr_env s1)
-  in (s1 { expr_env = h1 }, s2 { expr_env = h2 })
--}
 
 -- the left one takes precedence
 envMerge :: ExprEnv -> ExprEnv -> ExprEnv
@@ -742,9 +734,9 @@ moreRestrictiveEqual solver ns lemmas s1 s2 = do
   let h1 = expr_env s1
       h2 = expr_env s2
       -- TODO should this be syncSymbolic?
-      s1' = s1 { expr_env = E.union h1 h2 }
-      s2' = s2 { expr_env = E.union h2 h1 }
-      --(s1', s2') = syncSymbolic s1 s2
+      --s1' = s1 { expr_env = E.union h1 h2 }
+      --s2' = s2 { expr_env = E.union h2 h1 }
+      (s1', s2') = syncSymbolic s1 s2
   -- TODO only attempt if dc paths are the same
   --W.liftIO $ putStrLn $ "EQ? " ++ (folder_name $ track s1') ++ " " ++ (folder_name $ track s2')
   if dc_path (track s1') /= dc_path (track s2') then return Nothing

--- a/src/G2/Equiv/Tactics.hs
+++ b/src/G2/Equiv/Tactics.hs
@@ -47,7 +47,6 @@ import G2.Language
 import qualified Control.Monad.State.Lazy as CM
 
 import qualified G2.Language.ExprEnv as E
-import qualified G2.Language.Expr as X
 import G2.Language.Monad.AST
 import qualified G2.Language.Typing as T
 
@@ -178,27 +177,6 @@ moreRestrictivePC solver s1 s2 hm = do
   case res of
     S.UNSAT () -> return True
     _ -> return False
-
--- helper function to circumvent syncSymbolic
--- for symbolic things, lookup returns the variable
-lookupBoth :: Name -> ExprEnv -> ExprEnv -> Maybe Expr
-lookupBoth n h1 h2 = case E.lookupConcOrSym n h1 of
-  Just (E.Conc e) -> Just e
-  Just (E.Sym i) -> case E.lookup n h2 of
-                      Nothing -> Just $ Var i
-                      m -> m
-  Nothing -> E.lookup n h2
-
--- TODO doesn't count as symbolic if it's unmapped
--- condition we need:  n is symbolic in every env where it's mapped
-isSymbolicBoth :: Name -> ExprEnv -> ExprEnv -> Bool
-isSymbolicBoth n h1 h2 =
-  case E.lookupConcOrSym n h1 of
-    Just (E.Sym _) -> case E.lookupConcOrSym n h2 of
-                        Just (E.Conc _) -> False
-                        _ -> True
-    Just (E.Conc _) -> False
-    Nothing -> E.isSymbolic n h2
 
 -- s1 is the old state, s2 is the new state
 -- If any recursively-defined functions or other expressions manage to slip

--- a/src/G2/Equiv/Verifier.hs
+++ b/src/G2/Equiv/Verifier.hs
@@ -110,7 +110,7 @@ runSymExec solver config folder_root ns s1 s2 = do
       CurrExpr r1 e1 = curr_expr s1
       e1' = addStackTickIfNeeded ns (expr_env s1) e1
       s1' = s1 { track = t1, curr_expr = CurrExpr r1 e1' }
-  CM.liftIO $ putStrLn $ (folder_name $ track s1) ++ " becomes " ++ (folder_name t1)
+  --CM.liftIO $ putStrLn $ (folder_name $ track s1) ++ " becomes " ++ (folder_name t1)
   (er1, bindings') <- CM.lift $ runG2ForRewriteV solver s1' (expr_env s2) (track s2) config' bindings
   CM.put (bindings', k + 1)
   let final_s1 = map final_state er1
@@ -123,7 +123,7 @@ runSymExec solver config folder_root ns s1 s2 = do
                         CurrExpr r2 e2 = curr_expr s2_
                         e2' = addStackTickIfNeeded ns (expr_env s2) e2
                         s2' = s2_ { track = t2, curr_expr = CurrExpr r2 e2' }
-                    CM.liftIO $ putStrLn $ (folder_name $ track s2_) ++ " becomes " ++ (folder_name t2)
+                    --CM.liftIO $ putStrLn $ (folder_name $ track s2_) ++ " becomes " ++ (folder_name t2)
                     (er2, b_') <- CM.lift $ runG2ForRewriteV solver s2' (expr_env s1_) (track s1_) config'' b_
                     CM.put (b_', k_ + 1)
                     return $ map (\er2_ -> 
@@ -155,6 +155,7 @@ transferTrackerInfo s1 s2 =
         higher_order = higher_order t1
       , total = total t1
       , finite = finite t1
+      , opp_env = expr_env s1
       }
   in s2 { track = t2' }
 
@@ -738,9 +739,11 @@ tryDischarge solver tactics ns lemmas (fn:fresh_names) sh1 sh2 =
       case obs of
         [] -> W.tell [Marker (sh1, sh2) $ NoObligations (s1, s2)]
         _ -> return ()
+      {-
       W.liftIO $ putStrLn $ "J! " ++ (show $ folder_name $ track s1) ++ " " ++ (show $ folder_name $ track s2)
       W.liftIO $ putStrLn $ printPG pg ns (E.symbolicIds $ expr_env s1) s1
       W.liftIO $ putStrLn $ printPG pg ns (E.symbolicIds $ expr_env s2) s2
+      -}
       -- just like with tactics, we only need one fresh name here
       let states = map (stateWrap fn s1 s2) obs
       res <- mapM (applyTactics solver tactics ns lemmas [] fresh_names (sh1, sh2)) states
@@ -866,8 +869,8 @@ checkRule config init_state bindings total finite print_summary iterations rule 
       finite_hs = foldr HS.insert HS.empty finite_names
       -- always include the finite names in total
       total_hs = foldr HS.insert finite_hs total_names
-      EquivTracker et m _ _ _ _ = emptyEquivTracker
-      start_equiv_tracker = EquivTracker et m total_hs finite_hs [] ""
+      EquivTracker et m _ _ _ _ _ = emptyEquivTracker
+      start_equiv_tracker = EquivTracker et m total_hs finite_hs [] E.empty ""
       -- the keys are the same between the old and new environments
       ns_l = HS.fromList $ E.keys $ expr_env rewrite_state_l
       ns_r = HS.fromList $ E.keys $ expr_env rewrite_state_r

--- a/src/G2/Equiv/Verifier.hs
+++ b/src/G2/Equiv/Verifier.hs
@@ -110,7 +110,7 @@ runSymExec solver config folder_root ns s1 s2 = do
       CurrExpr r1 e1 = curr_expr s1
       e1' = addStackTickIfNeeded ns (expr_env s1) e1
       s1' = s1 { track = t1, curr_expr = CurrExpr r1 e1' }
-  --CM.liftIO $ putStrLn $ (folder_name $ track s1) ++ " becomes " ++ (folder_name t1)
+  CM.liftIO $ putStrLn $ (folder_name $ track s1) ++ " becomes " ++ (folder_name t1)
   (er1, bindings') <- CM.lift $ runG2ForRewriteV solver s1' (expr_env s2) (track s2) config' bindings
   CM.put (bindings', k + 1)
   let final_s1 = map final_state er1
@@ -123,7 +123,7 @@ runSymExec solver config folder_root ns s1 s2 = do
                         CurrExpr r2 e2 = curr_expr s2_
                         e2' = addStackTickIfNeeded ns (expr_env s2) e2
                         s2' = s2_ { track = t2, curr_expr = CurrExpr r2 e2' }
-                    --CM.liftIO $ putStrLn $ (folder_name $ track s2_) ++ " becomes " ++ (folder_name t2)
+                    CM.liftIO $ putStrLn $ (folder_name $ track s2_) ++ " becomes " ++ (folder_name t2)
                     (er2, b_') <- CM.lift $ runG2ForRewriteV solver s2' (expr_env s1_) (track s1_) config'' b_
                     CM.put (b_', k_ + 1)
                     return $ map (\er2_ -> 
@@ -738,11 +738,9 @@ tryDischarge solver tactics ns lemmas (fn:fresh_names) sh1 sh2 =
       case obs of
         [] -> W.tell [Marker (sh1, sh2) $ NoObligations (s1, s2)]
         _ -> return ()
-      {-
       W.liftIO $ putStrLn $ "J! " ++ (show $ folder_name $ track s1) ++ " " ++ (show $ folder_name $ track s2)
       W.liftIO $ putStrLn $ printPG pg ns (E.symbolicIds $ expr_env s1) s1
       W.liftIO $ putStrLn $ printPG pg ns (E.symbolicIds $ expr_env s2) s2
-      -}
       -- just like with tactics, we only need one fresh name here
       let states = map (stateWrap fn s1 s2) obs
       res <- mapM (applyTactics solver tactics ns lemmas [] fresh_names (sh1, sh2)) states

--- a/src/G2/Equiv/Verifier.hs
+++ b/src/G2/Equiv/Verifier.hs
@@ -116,7 +116,7 @@ runSymExec solver config folder_root ns s1 s2 = do
   let final_s1 = map final_state er1
   pairs <- mapM (\s1_ -> do
                     (b_, k_) <- CM.get
-                    let s2_ = transferTrackerInfo s1_ s2-- (snd $ syncSymbolic s1_ s2)
+                    let s2_ = transferTrackerInfo s1_ (snd $ syncSymbolic s1_ s2)
                     ct2 <- CM.liftIO $ getCurrentTime
                     let config'' = config { logStates = logStatesFolder ("b" ++ show k_) folder_root }
                         t2 = (track s2_) { folder_name = logStatesET ("b" ++ show k_) folder_root }
@@ -129,7 +129,7 @@ runSymExec solver config folder_root ns s1 s2 = do
                     return $ map (\er2_ -> 
                                     let
                                         s2_' = final_state er2_
-                                        s1_' = transferTrackerInfo s2_' s1_-- (snd $ syncSymbolic s2_' s1_)
+                                        s1_' = transferTrackerInfo s2_' (snd $ syncSymbolic s2_' s1_)
                                     in
                                     (addStamps k $ prepareState s1_', addStamps k_ $ prepareState s2_')
                                  ) er2) final_s1

--- a/src/G2/Equiv/Verifier.hs
+++ b/src/G2/Equiv/Verifier.hs
@@ -110,26 +110,26 @@ runSymExec solver config folder_root ns s1 s2 = do
       CurrExpr r1 e1 = curr_expr s1
       e1' = addStackTickIfNeeded ns (expr_env s1) e1
       s1' = s1 { track = t1, curr_expr = CurrExpr r1 e1' }
-  CM.liftIO $ putStrLn $ (folder_name $ track s1) ++ " becomes " ++ (folder_name t1)
+  --CM.liftIO $ putStrLn $ (folder_name $ track s1) ++ " becomes " ++ (folder_name t1)
   (er1, bindings') <- CM.lift $ runG2ForRewriteV solver s1' (expr_env s2) (track s2) config' bindings
   CM.put (bindings', k + 1)
   let final_s1 = map final_state er1
   pairs <- mapM (\s1_ -> do
                     (b_, k_) <- CM.get
-                    let s2_ = transferTrackerInfo s1_ (snd $ syncSymbolic s1_ s2)
+                    let s2_ = transferTrackerInfo s1_ s2-- (snd $ syncSymbolic s1_ s2)
                     ct2 <- CM.liftIO $ getCurrentTime
                     let config'' = config { logStates = logStatesFolder ("b" ++ show k_) folder_root }
                         t2 = (track s2_) { folder_name = logStatesET ("b" ++ show k_) folder_root }
                         CurrExpr r2 e2 = curr_expr s2_
                         e2' = addStackTickIfNeeded ns (expr_env s2) e2
                         s2' = s2_ { track = t2, curr_expr = CurrExpr r2 e2' }
-                    CM.liftIO $ putStrLn $ (folder_name $ track s2_) ++ " becomes " ++ (folder_name t2)
+                    --CM.liftIO $ putStrLn $ (folder_name $ track s2_) ++ " becomes " ++ (folder_name t2)
                     (er2, b_') <- CM.lift $ runG2ForRewriteV solver s2' (expr_env s1_) (track s1_) config'' b_
                     CM.put (b_', k_ + 1)
                     return $ map (\er2_ -> 
                                     let
                                         s2_' = final_state er2_
-                                        s1_' = transferTrackerInfo s2_' (snd $ syncSymbolic s2_' s1_)
+                                        s1_' = transferTrackerInfo s2_' s1_-- (snd $ syncSymbolic s2_' s1_)
                                     in
                                     (addStamps k $ prepareState s1_', addStamps k_ $ prepareState s2_')
                                  ) er2) final_s1

--- a/src/G2/Equiv/Verifier.hs
+++ b/src/G2/Equiv/Verifier.hs
@@ -155,7 +155,7 @@ transferTrackerInfo s1 s2 =
         higher_order = higher_order t1
       , total = total t1
       , finite = finite t1
-      , opp_env = expr_env s1
+      --, opp_env = expr_env s1
       }
   in s2 { track = t2' }
 

--- a/src/G2/Execution/Reducer.hs
+++ b/src/G2/Execution/Reducer.hs
@@ -413,6 +413,7 @@ data EquivTracker = EquivTracker { higher_order :: HM.HashMap Expr Id
                                  , total :: HS.HashSet Name
                                  , finite :: HS.HashSet Name
                                  , dc_path :: [BlockInfo]
+                                 , opp_env :: ExprEnv
                                  , folder_name :: String } deriving (Show, Eq, Generic)
 
 instance Hashable EquivTracker
@@ -427,7 +428,7 @@ instance Reducer ConcSymReducer () EquivTracker where
                             , expr_env = eenv
                             , type_env = tenv
                             , path_conds = pc
-                            , track = EquivTracker et m total finite dcp fname })
+                            , track = EquivTracker et m total finite dcp opp fname })
                    b@(Bindings { name_gen = ng })
         | E.isSymbolic n eenv
         , Just (dc_symbs, ng') <- arbDC tenv ng t n total = do
@@ -445,7 +446,7 @@ instance Reducer ConcSymReducer () EquivTracker where
                                         foldr E.insertSymbolic
                                               (E.insert n e eenv)
                                               symbs'
-                                    , track = EquivTracker et m total' finite' dcp fname
+                                    , track = EquivTracker et m total' finite' dcp opp fname
                                     }) dc_symbs
                 b' =  b { name_gen = ng' }
                 -- only add to total if n was total

--- a/src/G2/Language/ExprEnv.hs
+++ b/src/G2/Language/ExprEnv.hs
@@ -37,6 +37,8 @@ module G2.Language.ExprEnv
     , mapWithKey
     , mapWithKey'
     , mapConcWithKey
+    , mapConcOrSym
+    , mapConcOrSymWithKey
     , mapM
     , mapWithKeyM
     , filter
@@ -274,6 +276,20 @@ mapConcWithKey f (ExprEnv env) = ExprEnv $ M.mapWithKey f' env
         f' n (ExprObj e) = ExprObj $ f n e
         f' n s@(SymbObj _) = s
         f' _ n = n
+
+mapConcOrSym :: (ConcOrSym -> ConcOrSym) -> ExprEnv -> ExprEnv
+mapConcOrSym f = mapConcOrSymWithKey (\_ -> f)
+
+mapConcOrSymWithKey :: (Name -> ConcOrSym -> ConcOrSym) -> ExprEnv -> ExprEnv
+mapConcOrSymWithKey f (ExprEnv env) = ExprEnv $ M.mapWithKey f' env
+    where
+        g :: ConcOrSym -> EnvObj
+        g (Conc e) = ExprObj e
+        g (Sym i) = SymbObj i
+        f' :: Name -> EnvObj -> EnvObj
+        f' n (ExprObj e) = g $ f n $ Conc e
+        f' n (SymbObj i) = g $ f n $ Sym i
+        f' _ e = e
 
 mapM :: Monad m => (Expr -> m Expr) -> ExprEnv -> m ExprEnv
 mapM f eenv = return . ExprEnv =<< Pre.mapM f' (unwrapExprEnv eenv)

--- a/tests/RewriteVerify/Correct/Zeno.hs
+++ b/tests/RewriteVerify/Correct/Zeno.hs
@@ -1062,8 +1062,15 @@ plus a b = a + b
 badPlus :: Nat -> Nat -> Nat
 badPlus a b = S (a + b)
 
+xx :: Bool
+xx = xx
+
+yy :: Bool
+yy = yy
+
 {-# RULES
 "fg" f = g
 "fgBad" f = g . g
 "badPlus" plus = badPlus
+"contrived" xx = yy
   #-}

--- a/tests/scripts/zenoverify.py
+++ b/tests/scripts/zenoverify.py
@@ -974,8 +974,8 @@ def main():
     
     # TODO this is the real test suite
     # feel free to reduce the time from 180, but keep at least 150
-    t = 30
-    test_suite_csv(None, ground_truth, t)
+    t = 50
+    test_suite_csv(None, old_successes, t)
     #test_suite_csv("ZenoTrue", ground_truth, t)
     # test_suite_csv("ZenoAlteredTotal", totality_change(ground_truth), t)
     # TODO this is improper usage


### PR DESCRIPTION
Instead of taking expression environment unions every time we need to synchronize two states, we simply have each state hold onto the other state's expression environment.  This branch also includes a change to the way that we handle symbolic functions.