### PR TITLE
Lemma Markers

### DIFF
--- a/nebula/ZenoSuite.hs
+++ b/nebula/ZenoSuite.hs
@@ -196,6 +196,6 @@ suite n = do
                             (TranslationConfig {simpl = True, load_rewrite_rules = True}) config
   let rule_maybes = map (\t -> find (\r -> t == ru_name r) (rewrite_rules bindings)) texts
       rules = map fromJust rule_maybes
-  res <- mapM (\(r, t) -> checkRule config UseLabeledErrors False init_state bindings t [] NoSummary 10 r) (zip rules totals)
+  res <- mapM (\(r, t) -> checkRule config UseLabeledErrors False init_state bindings t [] (SM False False False) 10 r) (zip rules totals)
   print $ zip ri res
   return ()

--- a/src/G2/Equiv/Config.hs
+++ b/src/G2/Equiv/Config.hs
@@ -26,8 +26,6 @@ data SummaryMode = SM { have_summary :: Bool
 noSummary :: SummaryMode
 noSummary = SM False False False
 
--- data SummaryMode = NoHistory | WithHistory | NoSummary deriving Eq
-
 data UseLabeledErrors = UseLabeledErrors | NoLabeledErrors deriving (Eq, Show, Read)
 
 getNebulaConfig :: IO (String, String, [T.Text], NebulaConfig)

--- a/src/G2/Equiv/Config.hs
+++ b/src/G2/Equiv/Config.hs
@@ -19,7 +19,14 @@ data NebulaConfig = NC { limit :: Int
                        , log_states :: LogMode -- ^ Determines whether to Log states, and if logging states, how to do so.
                        , sync :: Bool }
 
-data SummaryMode = NoHistory | WithHistory | NoSummary deriving Eq
+data SummaryMode = SM { have_summary :: Bool
+                      , have_history :: Bool
+                      , have_lemma_details :: Bool }
+
+noSummary :: SummaryMode
+noSummary = SM False False False
+
+-- data SummaryMode = NoHistory | WithHistory | NoSummary deriving Eq
 
 data UseLabeledErrors = UseLabeledErrors | NoLabeledErrors deriving (Eq, Show, Read)
 
@@ -59,10 +66,18 @@ mkNebulaConfig = NC
 
 mkSummaryMode :: Parser SummaryMode
 mkSummaryMode =
-    (flag NoSummary NoHistory
+    (flag noSummary (SM True False False)
             (long "summarize"
             <> help "provide a summary with no history"))
     <|>
-    (flag NoSummary WithHistory
+    (flag noSummary (SM True True False)
             (long "hist-summarize"
             <> help "provide a summary with history"))
+    <|>
+    (flag noSummary (SM True False True)
+            (long "lemmas-summarize"
+            <> help "provide a summary with all lemma results"))
+    <|>
+    (flag noSummary (SM True True True)
+            (long "lemmas-hist-summarize"
+            <> help "provide a summary with history and lemma results"))

--- a/src/G2/Equiv/Summary.hs
+++ b/src/G2/Equiv/Summary.hs
@@ -4,6 +4,7 @@ module G2.Equiv.Summary
   ( SummaryMode (..)
   , summarize
   , summarizeAct
+  , summarizeLemmaMarker
   , printPG
   , showCX
   , showCycle
@@ -306,11 +307,18 @@ summarizeLemmaProvenEarly :: PrettyGuide ->
 summarizeLemmaProvenEarly = summarizeLemmaPair "Lemma Superseded"
 
 summarizeLemmaRejectedEarly :: PrettyGuide ->
-                                HS.HashSet Name ->
-                                [Id] ->
-                                (Lemma, Lemma) ->
-                                String
+                               HS.HashSet Name ->
+                               [Id] ->
+                               (Lemma, Lemma) ->
+                               String
 summarizeLemmaRejectedEarly = summarizeLemmaPair "Lemma Discarded"
+
+summarizeLemmaUnresolved :: PrettyGuide ->
+                            HS.HashSet Name ->
+                            [Id] ->
+                            Lemma ->
+                            String
+summarizeLemmaUnresolved = summarizeLemma "Lemma Unresolved"
 
 summarizeUnresolved :: PrettyGuide ->
                        HS.HashSet Name ->
@@ -346,34 +354,33 @@ summarizeLemmaPair str pg ns sym_ids (l1, l2) =
   printLemma pg ns sym_ids l1 ++ "\n" ++
   printLemma pg ns sym_ids l2
 
-summarizeAct :: SummaryMode
-             -> PrettyGuide
+-- TODO s_mode not used for now
+summarizeAct :: PrettyGuide
              -> HS.HashSet Name
              -> [Id]
              -> ActMarker
              -> String
-summarizeAct s_mode pg ns sym_ids m = case m of
+summarizeAct pg ns sym_ids m = case m of
   Coinduction cm -> summarizeCoinduction pg ns sym_ids cm
   Equality em -> summarizeEquality pg ns sym_ids em
   NoObligations s_pair -> summarizeNoObligations pg ns sym_ids s_pair
   NotEquivalent s_pair -> summarizeNotEquivalent pg ns sym_ids s_pair
   SolverFail s_pair -> summarizeSolverFail pg ns sym_ids s_pair
   CycleFound cm -> summarizeCycleFound pg ns sym_ids cm
-  LemmaProposed lem ->
-    if have_lemma_details s_mode
-    then summarizeLemmaProposed pg ns sym_ids lem
-    else ""
-  LemmaProven lem ->
-    if have_lemma_details s_mode
-    then summarizeLemmaProven pg ns sym_ids lem
-    else ""
-  LemmaRejected lem ->
-    if have_lemma_details s_mode
-    then summarizeLemmaRejected pg ns sym_ids lem
-    else ""
+  Unresolved s_pair -> summarizeUnresolved pg ns sym_ids s_pair
+
+summarizeLemmaMarker :: PrettyGuide
+                     -> HS.HashSet Name
+                     -> [Id]
+                     -> LemmaMarker
+                     -> String
+summarizeLemmaMarker pg ns sym_ids lm = case lm of
+  LemmaProposed l -> summarizeLemmaProposed pg ns sym_ids l
+  LemmaProven l -> summarizeLemmaProven pg ns sym_ids l
+  LemmaRejected l -> summarizeLemmaRejected pg ns sym_ids l
   LemmaProvenEarly lp -> summarizeLemmaProvenEarly pg ns sym_ids lp
   LemmaRejectedEarly lp -> summarizeLemmaRejectedEarly pg ns sym_ids lp
-  Unresolved s_pair -> summarizeUnresolved pg ns sym_ids s_pair
+  LemmaUnresolved l -> summarizeLemmaUnresolved pg ns sym_ids l
 
 summarizeHistory :: PrettyGuide -> HS.HashSet Name -> [Id] -> StateH -> String
 summarizeHistory pg ns sym_ids =
@@ -399,7 +406,11 @@ summarize s_mode pg ns sym_ids (Marker (sh1, sh2) m) =
             ++ "\nRight:\n\t" ++ tabsAfterNewLines (summarizeHistory pg ns sym_ids sh2) ++ "\n"
       else "")
   ++
-  (tabsAfterNewLines $ summarizeAct s_mode pg ns sym_ids m)
+  (tabsAfterNewLines $ summarizeAct pg ns sym_ids m)
+summarize s_mode pg ns sym_ids (LMarker lm) =
+  if have_lemma_details s_mode
+  then "***\n" ++ (tabsAfterNewLines $ summarizeLemmaMarker pg ns sym_ids lm)
+  else ""
 
 printDC :: PrettyGuide -> [BlockInfo] -> String -> String
 printDC _ [] str = str

--- a/src/G2/Equiv/Summary.hs
+++ b/src/G2/Equiv/Summary.hs
@@ -274,12 +274,12 @@ summarizeLemmaProvenEarly :: PrettyGuide ->
                              String
 summarizeLemmaProvenEarly = summarizeLemmaPair "Lemma Superseded"
 
-summarizeLemmaDisprovenEarly :: PrettyGuide ->
+summarizeLemmaRejectedEarly :: PrettyGuide ->
                                 HS.HashSet Name ->
                                 [Id] ->
                                 (Lemma, Lemma) ->
                                 String
-summarizeLemmaDisprovenEarly = summarizeLemmaPair "Lemma Discarded"
+summarizeLemmaRejectedEarly = summarizeLemmaPair "Lemma Discarded"
 
 summarizeUnresolved :: PrettyGuide ->
                        HS.HashSet Name ->
@@ -324,7 +324,7 @@ summarizeAct pg ns sym_ids m = case m of
   SolverFail s_pair -> summarizeSolverFail pg ns sym_ids s_pair
   CycleFound cm -> summarizeCycleFound pg ns sym_ids cm
   LemmaProvenEarly lp -> summarizeLemmaProvenEarly pg ns sym_ids lp
-  LemmaDisprovenEarly lp -> summarizeLemmaDisprovenEarly pg ns sym_ids lp
+  LemmaRejectedEarly lp -> summarizeLemmaRejectedEarly pg ns sym_ids lp
   Unresolved s_pair -> summarizeUnresolved pg ns sym_ids s_pair
 
 summarizeHistory :: PrettyGuide -> HS.HashSet Name -> [Id] -> StateH -> String

--- a/src/G2/Equiv/Tactics.hs
+++ b/src/G2/Equiv/Tactics.hs
@@ -849,7 +849,7 @@ insertDisprovenLemma solver ns lems lem = do
   -- the one doing the implying is the more general one
   let prop_lems = proposed_lemmas lems
   (extra_disproven, still_prop) <- partitionM (\l -> moreRestrictiveLemma solver ns lem [l]) prop_lems
-  let extra_pairs = map (\l -> LemmaDisprovenEarly (lem, l)) extra_disproven
+  let extra_pairs = map (\l -> LemmaRejectedEarly (lem, l)) extra_disproven
       -- all unresolved lemmas should have a non-empty singleton list
       markers = map (Marker . head . lemma_to_be_proven) extra_disproven
   W.tell $ map (\(m, a) -> m a) $ zip markers extra_pairs

--- a/src/G2/Equiv/Tactics.hs
+++ b/src/G2/Equiv/Tactics.hs
@@ -830,9 +830,7 @@ insertProvenLemma solver ns lems lem = do
   W.tell [LMarker $ LemmaProven lem]
   let prop_lems = proposed_lemmas lems
   (extra_proven, still_prop) <- partitionM (\l -> moreRestrictiveLemma solver ns l [lem]) prop_lems
-  let extra_pairs = map (\l -> LemmaProvenEarly (lem, l)) extra_proven
-      markers = map LMarker extra_pairs
-  W.tell markers
+  W.tell $ map (\l -> LMarker $ LemmaProvenEarly (lem, l)) extra_proven
   return $ lems {
       proposed_lemmas = still_prop
     , proven_lemmas = lem:(extra_proven ++ proven_lemmas lems)
@@ -852,7 +850,6 @@ insertDisprovenLemma solver ns lems lem = do
   -- the one doing the implying is the more general one
   let prop_lems = proposed_lemmas lems
   (extra_disproven, still_prop) <- partitionM (\l -> moreRestrictiveLemma solver ns lem [l]) prop_lems
-  -- all unresolved lemmas should have a non-empty singleton list
   W.tell $ map (\l -> LMarker $ LemmaRejectedEarly (lem, l)) extra_disproven
   return $ lems {
       proposed_lemmas = still_prop

--- a/src/G2/Equiv/Tactics.hs
+++ b/src/G2/Equiv/Tactics.hs
@@ -829,8 +829,8 @@ insertProvenLemma solver ns lems lem = do
   let prop_lems = proposed_lemmas lems
   (extra_proven, still_prop) <- partitionM (\l -> moreRestrictiveLemma solver ns l [lem]) prop_lems
   let extra_pairs = map (\l -> LemmaProvenEarly (lem, l)) extra_proven
-      markers = map (Marker . head . lemma_to_be_proven) extra_proven
-  W.tell $ map (\(m, a) -> m a) $ zip markers extra_pairs
+      markers = map LMarker extra_pairs
+  W.tell markers
   return $ lems {
       proposed_lemmas = still_prop
     , proven_lemmas = lem:(extra_proven ++ proven_lemmas lems)
@@ -849,10 +849,8 @@ insertDisprovenLemma solver ns lems lem = do
   -- the one doing the implying is the more general one
   let prop_lems = proposed_lemmas lems
   (extra_disproven, still_prop) <- partitionM (\l -> moreRestrictiveLemma solver ns lem [l]) prop_lems
-  let extra_pairs = map (\l -> LemmaRejectedEarly (lem, l)) extra_disproven
-      -- all unresolved lemmas should have a non-empty singleton list
-      markers = map (Marker . head . lemma_to_be_proven) extra_disproven
-  W.tell $ map (\(m, a) -> m a) $ zip markers extra_pairs
+  -- all unresolved lemmas should have a non-empty singleton list
+  W.tell $ map (\l -> LMarker $ LemmaRejectedEarly (lem, l)) extra_disproven
   return $ lems {
       proposed_lemmas = still_prop
     , disproven_lemmas = lem:(extra_disproven ++ disproven_lemmas lems)

--- a/src/G2/Equiv/Types.hs
+++ b/src/G2/Equiv/Types.hs
@@ -95,7 +95,6 @@ instance Named LemmaMarker where
     LemmaRejectedEarly lp -> LemmaRejectedEarly $ rename old new lp
     LemmaUnresolved l -> LemmaUnresolved $ rename old new l
 
--- TODO stratify the two kinds of markers
 data Marker = Marker (StateH, StateH) ActMarker
             | LMarker LemmaMarker
 

--- a/src/G2/Equiv/Types.hs
+++ b/src/G2/Equiv/Types.hs
@@ -48,15 +48,17 @@ data PrevMatch t = PrevMatch {
   , container :: State t
 }
 
--- TODO new constructor for lemma proving
 data ActMarker = Coinduction CoMarker
                | Equality EqualMarker
                | NoObligations (StateET, StateET)
                | NotEquivalent (StateET, StateET)
                | SolverFail (StateET, StateET)
                | CycleFound CycleMarker
+               | LemmaProposed Lemma
+               | LemmaProven Lemma
+               | LemmaRejected Lemma
                | LemmaProvenEarly (Lemma, Lemma)
-               | LemmaDisprovenEarly (Lemma, Lemma)
+               | LemmaRejectedEarly (Lemma, Lemma)
                | Unresolved (StateET, StateET)
 
 instance Named ActMarker where
@@ -66,8 +68,11 @@ instance Named ActMarker where
   names (NotEquivalent s_pair) = names s_pair
   names (SolverFail s_pair) = names s_pair
   names (CycleFound cm) = names cm
+  names (LemmaProposed lem) = names lem
+  names (LemmaProven lem) = names lem
+  names (LemmaRejected lem) = names lem
   names (LemmaProvenEarly l_pair) = names l_pair
-  names (LemmaDisprovenEarly l_pair) = names l_pair
+  names (LemmaRejectedEarly l_pair) = names l_pair
   names (Unresolved s_pair) = names s_pair
   rename old new m = case m of
     Coinduction cm -> Coinduction $ rename old new cm
@@ -77,7 +82,7 @@ instance Named ActMarker where
     SolverFail s_pair -> SolverFail $ rename old new s_pair
     CycleFound cm -> CycleFound $ rename old new cm
     LemmaProvenEarly lp -> LemmaProvenEarly $ rename old new lp
-    LemmaDisprovenEarly lp -> LemmaDisprovenEarly $ rename old new lp
+    LemmaRejectedEarly lp -> LemmaRejectedEarly $ rename old new lp
     Unresolved s_pair -> Unresolved $ rename old new s_pair
 
 data Marker = Marker (StateH, StateH) ActMarker

--- a/src/G2/Equiv/Types.hs
+++ b/src/G2/Equiv/Types.hs
@@ -54,11 +54,6 @@ data ActMarker = Coinduction CoMarker
                | NotEquivalent (StateET, StateET)
                | SolverFail (StateET, StateET)
                | CycleFound CycleMarker
-               | LemmaProposed Lemma
-               | LemmaProven Lemma
-               | LemmaRejected Lemma
-               | LemmaProvenEarly (Lemma, Lemma)
-               | LemmaRejectedEarly (Lemma, Lemma)
                | Unresolved (StateET, StateET)
 
 instance Named ActMarker where
@@ -68,11 +63,6 @@ instance Named ActMarker where
   names (NotEquivalent s_pair) = names s_pair
   names (SolverFail s_pair) = names s_pair
   names (CycleFound cm) = names cm
-  names (LemmaProposed lem) = names lem
-  names (LemmaProven lem) = names lem
-  names (LemmaRejected lem) = names lem
-  names (LemmaProvenEarly l_pair) = names l_pair
-  names (LemmaRejectedEarly l_pair) = names l_pair
   names (Unresolved s_pair) = names s_pair
   rename old new m = case m of
     Coinduction cm -> Coinduction $ rename old new cm
@@ -81,17 +71,42 @@ instance Named ActMarker where
     NotEquivalent s_pair -> NotEquivalent $ rename old new s_pair
     SolverFail s_pair -> SolverFail $ rename old new s_pair
     CycleFound cm -> CycleFound $ rename old new cm
-    LemmaProvenEarly lp -> LemmaProvenEarly $ rename old new lp
-    LemmaRejectedEarly lp -> LemmaRejectedEarly $ rename old new lp
     Unresolved s_pair -> Unresolved $ rename old new s_pair
 
+data LemmaMarker = LemmaProposed Lemma
+                 | LemmaProven Lemma
+                 | LemmaRejected Lemma
+                 | LemmaProvenEarly (Lemma, Lemma)
+                 | LemmaRejectedEarly (Lemma, Lemma)
+                 | LemmaUnresolved Lemma
+
+instance Named LemmaMarker where
+  names (LemmaProposed l) = names l
+  names (LemmaProven l) = names l
+  names (LemmaRejected l) = names l
+  names (LemmaProvenEarly l_pair) = names l_pair
+  names (LemmaRejectedEarly l_pair) = names l_pair
+  names (LemmaUnresolved l) = names l
+  rename old new lm = case lm of
+    LemmaProposed l -> LemmaProposed $ rename old new l
+    LemmaProven l -> LemmaProven $ rename old new l
+    LemmaRejected l -> LemmaRejected $ rename old new l
+    LemmaProvenEarly lp -> LemmaProvenEarly $ rename old new lp
+    LemmaRejectedEarly lp -> LemmaRejectedEarly $ rename old new lp
+    LemmaUnresolved l -> LemmaUnresolved $ rename old new l
+
+-- TODO stratify the two kinds of markers
 data Marker = Marker (StateH, StateH) ActMarker
+            | LMarker LemmaMarker
 
 instance Named Marker where
   names (Marker (sh1, sh2) m) =
     names sh1 DS.>< names sh2 DS.>< names m
+  names (LMarker lm) = names lm
   rename old new (Marker (sh1, sh2) m) =
     Marker (rename old new sh1, rename old new sh2) $ rename old new m
+  rename old new (LMarker lm) =
+    LMarker $ rename old new lm
 
 data Side = ILeft | IRight deriving (Eq, Show, Typeable, Generic)
 

--- a/src/G2/Equiv/Verifier.hs
+++ b/src/G2/Equiv/Verifier.hs
@@ -799,10 +799,10 @@ checkRule config nc init_state bindings total rule = do
              emptyLemmas
              [(rewrite_state_l'', rewrite_state_r'')]
              bindings'' config nc sym_ids 0 (limit nc)
-  let pg = if (print_summary nc) == NoSummary
-           then reducedGuide (reverse w)
-           else mkPrettyGuide $ map (\(Marker _ am) -> am) w
-  if print_summary nc /= NoSummary then do
+  let pg = if have_summary $ print_summary nc
+           then mkPrettyGuide $ map (\(Marker _ am) -> am) w
+           else reducedGuide (reverse w)
+  if have_summary $ print_summary nc then do
     putStrLn "--- SUMMARY ---"
     _ <- mapM (putStrLn . (summarize (print_summary nc) pg ns sym_ids)) w
     putStrLn "--- END OF SUMMARY ---"

--- a/src/G2/Equiv/Verifier.hs
+++ b/src/G2/Equiv/Verifier.hs
@@ -356,11 +356,6 @@ verifyLoop solver num_lems ns lemmas states b config nc sym_ids k n | (n /= 0) |
     W.liftIO $ putStrLn $ "proposed = " ++ show (length $ proposedLemmas lemmas)
     W.liftIO $ putStrLn $ "proven = " ++ show (length $ provenLemmas lemmas) 
     W.liftIO $ putStrLn $ "disproven = " ++ show (length $ disprovenLemmas lemmas)
-    -- TODO one option is to insert every lemma marker at the end
-    -- not sure if it would be better to mix them with everything else
-    -- TODO need a StateH for every lemma?
-    -- TODO this is only shown when loop iterations run out
-    -- TODO this also doesn't show how much progress has been made on that lemma
     W.liftIO $ putStrLn $ "Unresolved Obligations: " ++ show (length states)
     let ob (sh1, sh2) = Marker (sh1, sh2) $ Unresolved (latest sh1, latest sh2)
         un l = LMarker $ LemmaUnresolved l

--- a/src/G2/Equiv/Verifier.hs
+++ b/src/G2/Equiv/Verifier.hs
@@ -338,12 +338,6 @@ verifyLoop solver num_lems ns lemmas states b config nc sym_ids k n | (n /= 0) |
                   final_lemmas <- foldM (flip (insertProposedLemma solver ns))
                                         lemmas''
                                         (pl_lemmas ++ new_lemmas)
-
-                  -- mapM (\l@(le1, le2) -> do
-                  --               let pg = mkPrettyGuide l
-                  --               W.liftIO $ putStrLn "----"
-                  --               W.liftIO $ putStrLn $ printPG pg ns (E.symbolicIds $ expr_env le1) le1
-                  --               W.liftIO $ putStrLn $ printPG pg ns (E.symbolicIds $ expr_env le2) le2) $ HS.toList new_lemmas
                   verifyLoop solver num_lems ns final_lemmas new_obligations b'''' config nc sym_ids k''' n'
               CounterexampleFound -> do
                   let un l = LMarker $ LemmaUnresolved l
@@ -355,11 +349,6 @@ verifyLoop solver num_lems ns lemmas states b config nc sym_ids k n | (n /= 0) |
                       un_lemmas = (proposedLemmas lemmas \\ provenLemmas lemmas) \\ disprovenLemmas lemmas
                   W.tell $ map un un_lemmas
                   W.liftIO $ putStrLn $ "proposed = " ++ show (length $ proposedLemmas lemmas)
-                  -- mapM (\l@(Lemma le1 le2 _) -> do
-                  --               let pg = mkPrettyGuide l
-                  --               W.liftIO $ putStrLn "----"
-                  --               W.liftIO $ putStrLn $ printPG pg ns (E.symbolicIds $ expr_env le1) le1
-                  --               W.liftIO $ putStrLn $ printPG pg ns (E.symbolicIds $ expr_env le2) le2) $ proposedLemmas lemmas
                   W.liftIO $ putStrLn $ "proven = " ++ show (length $ provenLemmas lemmas) 
                   W.liftIO $ putStrLn $ "disproven = " ++ show (length $ disprovenLemmas lemmas) 
                   return $ S.UNSAT ()
@@ -367,26 +356,6 @@ verifyLoop solver num_lems ns lemmas states b config nc sym_ids k n | (n /= 0) |
     W.liftIO $ putStrLn $ "proposed = " ++ show (length $ proposedLemmas lemmas)
     W.liftIO $ putStrLn $ "proven = " ++ show (length $ provenLemmas lemmas) 
     W.liftIO $ putStrLn $ "disproven = " ++ show (length $ disprovenLemmas lemmas)
-    {-
-    mapM (\l@(Lemma { lemma_lhs = le1, lemma_rhs = le2}) -> do
-                  let pg = mkPrettyGuide l
-                  W.liftIO $ putStrLn "---- Proven ----"
-                  W.liftIO $ putStrLn $ lemma_name l
-                  W.liftIO $ putStrLn $ printPG pg ns (E.symbolicIds $ expr_env le1) le1
-                  W.liftIO $ putStrLn $ printPG pg ns (E.symbolicIds $ expr_env le2) le2) (provenLemmas lemmas)
-    mapM (\l@(Lemma { lemma_lhs = le1, lemma_rhs = le2}) -> do
-                  let pg = mkPrettyGuide l
-                  W.liftIO $ putStrLn "---- Disproven ----"
-                  W.liftIO $ putStrLn $ lemma_name l
-                  W.liftIO $ putStrLn $ printPG pg ns (E.symbolicIds $ expr_env le1) le1
-                  W.liftIO $ putStrLn $ printPG pg ns (E.symbolicIds $ expr_env le2) le2) (disprovenLemmas lemmas)
-    mapM (\l@(Lemma { lemma_lhs = le1, lemma_rhs = le2}) -> do
-                  let pg = mkPrettyGuide l
-                  W.liftIO $ putStrLn "---- Proposed ----"
-                  W.liftIO $ putStrLn $ lemma_name l
-                  W.liftIO $ putStrLn $ printPG pg ns (E.symbolicIds $ expr_env le1) le1
-                  W.liftIO $ putStrLn $ printPG pg ns (E.symbolicIds $ expr_env le2) le2) (proposedLemmas lemmas)
-    -}
     -- TODO one option is to insert every lemma marker at the end
     -- not sure if it would be better to mix them with everything else
     -- TODO need a StateH for every lemma?

--- a/tests/RewriteVerify/RewriteVerifyTest.hs
+++ b/tests/RewriteVerify/RewriteVerifyTest.hs
@@ -47,7 +47,7 @@ rejectRule config init_state bindings rule = do
 nebulaConfig :: NebulaConfig
 nebulaConfig = NC { limit = 20
                   , num_lemmas = 2
-                  , print_summary = NoSummary
+                  , print_summary = SM False False False
                   , use_labeled_errors = UseLabeledErrors
                   , log_states = NoLog
                   , sync = False}


### PR DESCRIPTION
There is now a dedicated type of marker for information relating to lemmas.  These markers have their own configuration option and will be displayed only when it is enabled.  Lemma markers are interleaved with ordinary markers in the summaries that are displayed.