### PR TITLE
Opt

### DIFF
--- a/g2.cabal
+++ b/g2.cabal
@@ -239,11 +239,11 @@ library
 
   default-language:    Haskell2010
   ghc-options:         -Wall
-                       -O1
+                       -- -O1
                        -fno-ignore-asserts
                        -- -ddump-rule-rewrites
                        -- -ddump-splices
-                       -fprof-auto
+                       -- -fprof-auto
                        -- -fexternal-interpreter
   other-extensions:    CPP
   if flag(support-lh) && impl(ghc < 9)
@@ -264,7 +264,7 @@ executable G2
   default-language:    Haskell2010
   ghc-options:         -threaded -Wall
                       --  -fprof-auto "-with-rtsopts=+RTS -xc"
-                       -fprof-auto "-with-rtsopts=-p"
+                       -- -fprof-auto "-with-rtsopts=-p"
                        -- -fexternal-interpreter -opti+RTS -opti-p
   hs-source-dirs:      exe
   main-is:             Main.hs
@@ -362,7 +362,7 @@ test-suite test
                        , UnionFindTests
                        , RewriteVerify.RewriteVerifyTest
   ghc-options:         -Wall
-                       -fprof-auto "-with-rtsopts=-p"
+                       -- -fprof-auto "-with-rtsopts=-p"
                        -threaded
   type:                exitcode-stdio-1.0
 
@@ -395,7 +395,7 @@ test-suite test-lh
                        , TestUtils
                        , UnionPoly
   ghc-options:         -Wall
-                       -fprof-auto "-with-rtsopts=-p"
+                       -- -fprof-auto "-with-rtsopts=-p"
                        -threaded
   type:                exitcode-stdio-1.0
 

--- a/g2.cabal
+++ b/g2.cabal
@@ -239,11 +239,11 @@ library
 
   default-language:    Haskell2010
   ghc-options:         -Wall
-                      --  -O1
+                       -O1
                        -fno-ignore-asserts
                        -- -ddump-rule-rewrites
                        -- -ddump-splices
-                      --  -fprof-auto
+                       -fprof-auto
                        -- -fexternal-interpreter
   other-extensions:    CPP
   if flag(support-lh) && impl(ghc < 9)
@@ -362,7 +362,7 @@ test-suite test
                        , UnionFindTests
                        , RewriteVerify.RewriteVerifyTest
   ghc-options:         -Wall
-                       -- -fprof-auto "-with-rtsopts=-p"
+                       -fprof-auto "-with-rtsopts=-p"
                        -threaded
   type:                exitcode-stdio-1.0
 
@@ -395,7 +395,7 @@ test-suite test-lh
                        , TestUtils
                        , UnionPoly
   ghc-options:         -Wall
-                       -- -fprof-auto "-with-rtsopts=-p"
+                       -fprof-auto "-with-rtsopts=-p"
                        -threaded
   type:                exitcode-stdio-1.0
 

--- a/g2.cabal
+++ b/g2.cabal
@@ -264,7 +264,7 @@ executable G2
   default-language:    Haskell2010
   ghc-options:         -threaded -Wall
                       --  -fprof-auto "-with-rtsopts=+RTS -xc"
-                      --  -fprof-auto "-with-rtsopts=-p"
+                       -fprof-auto "-with-rtsopts=-p"
                        -- -fexternal-interpreter -opti+RTS -opti-p
   hs-source-dirs:      exe
   main-is:             Main.hs

--- a/src/G2/Execution/Reducer.hs
+++ b/src/G2/Execution/Reducer.hs
@@ -392,6 +392,7 @@ redRulesToStates r rv1 s b = do
     return $ (rf, concat s', b')
 
 {-#INLINE stdRed #-}
+{-# SPECIALIZE stdRed :: (Solver solver, Simplifier simplifier) => Sharing -> solver -> simplifier -> Reducer IO () t #-}
 stdRed :: (MonadIO m, Solver solver, Simplifier simplifier) => Sharing -> solver -> simplifier -> Reducer m () t
 stdRed share solver simplifier =
         mkSimpleReducer (\_ -> ())
@@ -1050,6 +1051,22 @@ quotTrueAssert ord = (mkSimpleOrderer (initPerStateOrder ord)
 --------
 --------
 
+{-# SPECIALIZE runReducer :: Ord b =>
+                             Reducer IO rv t
+                          -> Halter IO hv t
+                          -> Orderer sov b t
+                          -> State t
+                          -> Bindings
+                          -> IO (Processed (State t), Bindings)
+    #-}
+{-# SPECIALIZE runReducer :: Ord b =>
+                             Reducer (SM.StateT PrettyGuide IO) rv t
+                          -> Halter (SM.StateT PrettyGuide IO) hv t
+                          -> Orderer sov b t
+                          -> State t
+                          -> Bindings
+                          -> SM.StateT PrettyGuide IO (Processed (State t), Bindings)
+    #-}
 -- | Uses a passed Reducer, Halter and Orderer to execute the reduce on the State, and generated States
 runReducer :: (MonadIO m, Ord b) =>
               Reducer m rv t

--- a/src/G2/Initialization/ElimTypeSynonyms.hs
+++ b/src/G2/Initialization/ElimTypeSynonyms.hs
@@ -8,7 +8,7 @@ import G2.Language
 import qualified Data.HashMap.Lazy as HM
 
 elimTypeSyms :: ASTContainer m Type => TypeEnv -> m -> m
-elimTypeSyms tenv = modifyASTsFix (elimTypeSyms' tenv)
+elimTypeSyms tenv = modifyASTs (elimTypeSyms' tenv)
 
 elimTypeSyms' :: TypeEnv -> Type -> Type
 elimTypeSyms' tenv t
@@ -16,7 +16,8 @@ elimTypeSyms' tenv t
     , ts <- tyAppArgs t
     , Just (TypeSynonym { bound_ids = is, synonym_of = st }) <- HM.lookup n tenv
     , length ts == length is =
-    foldr (uncurry replaceASTs) st $ zip (map TyVar is) ts
+    -- We recursively call elimTypeSyms, in case a type synonym  maps directly to a type synonym
+    elimTypeSyms' tenv $ foldr (uncurry replaceASTs) st $ zip (map TyVar is) ts
 elimTypeSyms' _ t = t
 
 elimTypeSymsTEnv :: TypeEnv -> TypeEnv

--- a/src/G2/Interface/Interface.hs
+++ b/src/G2/Interface/Interface.hs
@@ -242,6 +242,13 @@ initCheckReaches s@(State { expr_env = eenv
                           , known_values = kv }) m_mod reaches =
     s {expr_env = checkReaches eenv kv reaches m_mod }
 
+{-# SPECIALIZE 
+    initRedHaltOrd :: (Solver solver, Simplifier simplifier) =>
+                      solver
+                   -> simplifier
+                   -> Config
+                   -> (SomeReducer (SM.StateT PrettyGuide IO) (), SomeHalter (SM.StateT PrettyGuide IO) (), SomeOrderer ())
+    #-}
 initRedHaltOrd :: (MonadIO m, Solver solver, Simplifier simplifier) =>
                   solver
                -> simplifier
@@ -379,6 +386,20 @@ runG2WithConfig state config bindings = do
 
     return (in_out, bindings')
 
+
+{-# SPECIALIZE 
+    runG2WithSomes :: ( Solver solver
+                      , Simplifier simplifier)
+                => SomeReducer (SM.StateT PrettyGuide IO) ()
+                -> SomeHalter (SM.StateT PrettyGuide IO) ()
+                -> SomeOrderer ()
+                -> solver
+                -> simplifier
+                -> MemConfig
+                -> State ()
+                -> Bindings
+                -> SM.StateT PrettyGuide IO ([ExecRes ()], Bindings)
+    #-}
 runG2WithSomes :: ( MonadIO m
                   , Named t
                   , ASTContainer t Expr

--- a/src/G2/Language/AST.hs
+++ b/src/G2/Language/AST.hs
@@ -10,6 +10,7 @@ module G2.Language.AST
     , modify
     , modifyMonoid
     , modifyFix
+    , modifyMaybe
     , modifyContainedFix
     , modifyFixMonoid
     , eval
@@ -71,6 +72,16 @@ modifyFix f t = go t
     where
         go t' = let t'' = f t'
                 in if t' == t'' then modifyChildren go t'' else go t''
+
+-- | Runs the given function f on the node t repeatedly, until f t = Nothing, then does the
+-- same on all decendants of t recursively.
+modifyMaybe :: AST t => (t -> Maybe t) -> t -> t
+modifyMaybe f = go
+    where
+        go t = let mt = f t in
+                case mt of
+                    Just v -> go v
+                    Nothing -> modifyChildren go t
 
 -- | Runs the given function f on the node t, t until t = f t
 modifyContainedFix :: (AST t, Eq t, Show t) => (t -> t) -> t -> t

--- a/src/G2/Language/Expr.hs
+++ b/src/G2/Language/Expr.hs
@@ -120,8 +120,11 @@ eqUpToTypes _ _ = False
 
 -- | Unravels the application spine.
 unApp :: Expr -> [Expr]
-unApp (App f a) = unApp f ++ [a]
-unApp expr = [expr]
+unApp = unApp' []
+
+unApp' :: [Expr] -> Expr -> [Expr]
+unApp' xs (App f a) = unApp' (a:xs) f
+unApp' xs e = e:xs
 
 -- | Turns the Expr list into an Application
 --

--- a/src/G2/Lib/Printers.hs
+++ b/src/G2/Lib/Printers.hs
@@ -51,7 +51,7 @@ mkNameHaskell pg n
 
 mkUnsugaredExprHaskell :: State t -> Expr -> String
 mkUnsugaredExprHaskell (State {known_values = kv, type_classes = tc}) =
-    mkExprHaskell Cleaned (mkPrettyGuide ()) . modifyFix (mkCleanExprHaskell' kv tc)
+    mkExprHaskell Cleaned (mkPrettyGuide ()) . modifyMaybe (mkCleanExprHaskell' kv tc)
 
 printHaskell :: State t -> Expr -> String
 printHaskell = mkCleanExprHaskell (mkPrettyGuide ())
@@ -67,27 +67,27 @@ printHaskellPG = mkCleanExprHaskell
 
 mkCleanExprHaskell :: PrettyGuide -> State t -> Expr -> String
 mkCleanExprHaskell pg (State {known_values = kv, type_classes = tc}) = 
-    mkExprHaskell Cleaned pg . modifyFix (mkCleanExprHaskell' kv tc)
+    mkExprHaskell Cleaned pg . modifyMaybe (mkCleanExprHaskell' kv tc)
 
-mkCleanExprHaskell' :: KnownValues -> TypeClasses -> Expr -> Expr
+mkCleanExprHaskell' :: KnownValues -> TypeClasses -> Expr -> Maybe Expr
 mkCleanExprHaskell' kv tc e
     | (App (Data (DataCon n _)) e') <- e
-    , n == dcInt kv || n == dcFloat kv || n == dcDouble kv || n == dcInteger kv || n == dcChar kv = e'
+    , n == dcInt kv || n == dcFloat kv || n == dcDouble kv || n == dcInteger kv || n == dcChar kv = Just e'
 
     | (App e' e'') <- e
     , t <- typeOf e'
-    , isTypeClass tc t = e''
+    , isTypeClass tc t = Just e''
 
     | (App e' e'') <- e
     , t <- typeOf e''
-    , isTypeClass tc t = e'
+    , isTypeClass tc t = Just e'
 
     | (App e' e'') <- e
-    , isTypeClass tc (returnType e'') = e'
+    , isTypeClass tc (returnType e'') = Just e'
 
-    | App e' (Type _) <- e = e'
+    | App e' (Type _) <- e = Just e'
 
-    | otherwise = e
+    | otherwise = Nothing
 
 mkDirtyExprHaskell :: PrettyGuide -> Expr -> String
 mkDirtyExprHaskell = mkExprHaskell Dirty

--- a/src/G2/QuasiQuotes/G2Rep.hs
+++ b/src/G2/QuasiQuotes/G2Rep.hs
@@ -1,4 +1,3 @@
--- Hides the warnings about deriving 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}


### PR DESCRIPTION
Results of profiling `cabal run test` before changes:
```
	Thu Mar  9 16:56 2023 Time and Allocation Profiling Report  (Final)

	   test +RTS -p -RTS

	total time  =      186.02 secs   (186019 ticks @ 1000 us, 1 processor)
	total alloc = 436,891,732,432 bytes  (excludes profiling overheads)
```
Results after changes:
```
	Fri Mar 10 12:02 2023 Time and Allocation Profiling Report  (Final)

	   test +RTS -p -RTS

	total time  =      157.32 secs   (157316 ticks @ 1000 us, 1 processor)
	total alloc = 425,505,650,656 bytes  (excludes profiling overheads)
```