### PR TITLE
Optimization to moreRestrictive

### DIFF
--- a/src/G2/Equiv/G2Calls.hs
+++ b/src/G2/Equiv/G2Calls.hs
@@ -17,6 +17,7 @@ module G2.Equiv.G2Calls ( StateET
                         , isLabeledError
 
                         , lookupBoth
+                        , lookupConcOrSymBoth
                         , isSymbolicBoth ) where
 
 import G2.Config
@@ -447,12 +448,15 @@ totalExpr s@(State { expr_env = h, track = EquivTracker _ _ total _ h' _ }) ns n
 -- helper function to circumvent syncSymbolic
 -- for symbolic things, lookup returns the variable
 lookupBoth :: Name -> ExprEnv -> ExprEnv -> Maybe Expr
-lookupBoth n h1 h2 = case E.lookupConcOrSym n h1 of
-  Just (E.Conc e) -> Just e
-  Just (E.Sym i) -> case E.lookup n h2 of
-                      Nothing -> Just $ Var i
+lookupBoth n h1 = fmap E.concOrSymToExpr . lookupConcOrSymBoth n h1
+
+lookupConcOrSymBoth :: Name -> ExprEnv -> ExprEnv -> Maybe E.ConcOrSym
+lookupConcOrSymBoth n h1 h2 = case E.lookupConcOrSym n h1 of
+  e@(Just (E.Conc _)) -> e
+  sym@(Just (E.Sym _)) -> case E.lookupConcOrSym n h2 of
+                      Nothing -> sym
                       m -> m
-  Nothing -> E.lookup n h2
+  Nothing -> E.lookupConcOrSym n h2
 
 -- doesn't count as symbolic if it's unmapped
 -- condition we need:  n is symbolic in every env where it's mapped

--- a/src/G2/Language/ExprEnv.hs
+++ b/src/G2/Language/ExprEnv.hs
@@ -8,6 +8,9 @@ module G2.Language.ExprEnv
     ( ExprEnv
     , ConcOrSym (..)
     , EnvObj (..)
+
+    , concOrSymToExpr
+
     , empty
     , singleton
     , fromList
@@ -85,6 +88,10 @@ import GHC.Generics (Generic)
 data ConcOrSym = Conc Expr
                | Sym Id
                deriving (Show)
+
+concOrSymToExpr :: ConcOrSym -> Expr
+concOrSymToExpr (Conc e) = e
+concOrSymToExpr (Sym i) = Var i
 
 -- From a user perspective, `ExprEnv`s are mappings from `Name` to
 -- `Expr`s. however, there are two complications:


### PR DESCRIPTION
Decreases total run time and memory allocation on rewriting tests.  Profiling with:
```
time cabal run test -- -p "Rewrite"   
```
before changes:
```
	total time  =       58.79 secs   (58789 ticks @ 1000 us, 1 processor)
	total alloc = 112,121,837,616 bytes  (excludes profiling overheads)

COST CENTRE                    MODULE                 SRC                                                  %time %alloc

lookupConcOrSym                G2.Language.ExprEnv    src/G2/Language/ExprEnv.hs:(153,1)-(158,26)           11.1    3.2
moreRestrictive                G2.Equiv.Tactics       src/G2/Equiv/Tactics.hs:(202,1)-(348,16)              10.4    4.9
hashWithSalt                   G2.Language.Syntax     src/G2/Language/Syntax.hs:(50,5)-(53,26)               5.7    2.5
tc_rn_src_decls                GHC.Tc.Module          compiler/GHC/Tc/Module.hs:(608,4)-(679,7)              4.4    4.6
hashWithSalt1                  Data.Hashable.Class    src/Data/Hashable/Class.hs:278:1-45                    3.9    2.5
Parser                         GHC.Driver.Main        compiler/GHC/Driver/Main.hs:(421,26)-(507,30)          3.6   10.5
member                         Data.HashSet.Internal  Data/HashSet/Internal.hs:(348,1)-(350,30)              3.3    0.0
deSugar                        GHC.Driver.Main        compiler/GHC/Driver/Main.hs:689:7-44                   3.2    5.5
hash                           G2.Language.Syntax     src/G2/Language/Syntax.hs:49:10-22                     2.9    2.3
modifyChildrenM                G2.Language.Monad.AST  src/G2/Language/Monad/AST.hs:(39,5)-(65,34)            2.7    4.7
hash                           Data.HashMap.Internal  Data/HashMap/Internal.hs:180:1-28                      2.2    0.0
getPreprocessedImports         GHC.Driver.Make        compiler/GHC/Driver/Make.hs:(2114,1)-(2128,33)         2.0    3.4
modifyChildren                 G2.Language.AST        src/G2/Language/AST.hs:(210,5)-(215,26)                1.7    6.7
simplIdF                       GHC.Core.Opt.Simplify  compiler/GHC/Core/Opt/Simplify.hs:1146:61-79           1.5    2.3
modifyContainedASTsM           G2.Language.Monad.AST  src/G2/Language/Monad/AST.hs:(172,5)-(174,25)          1.5    2.2
appTypeOf                      G2.Language.Typing     src/G2/Language/Typing.hs:(233,1)-(247,79)             1.4    0.9
==                             G2.Language.Syntax     src/G2/Language/Syntax.hs:42:5-67                      1.1    0.0
passedArgs'                    G2.Language.Typing     src/G2/Language/Typing.hs:(225,1)-(226,18)             1.1    2.3
hashByteArrayWithSalt          Data.Hashable.LowLevel src/Data/Hashable/LowLevel.hs:(109,1)-(111,20)         1.0    1.2
unApp'                         G2.Language.Expr       src/G2/Language/Expr.hs:(127,1)-(128,18)               0.9    2.1
simplTopBinds-simpl_binds      GHC.Core.Opt.Simplify  compiler/GHC/Core/Opt/Simplify.hs:221:68-90            0.9    1.0
occAnalBind.assoc              GHC.Core.Opt.OccurAnal compiler/GHC/Core/Opt/OccurAnal.hs:821:13-64           0.8    1.5
byteCodeGen                    GHC.StgToByteCode      compiler/GHC/StgToByteCode.hs:(103,1)-(148,38)         0.6    1.4
OccAnal                        GHC.Core.Opt.Pipeline  compiler/GHC/Core/Opt/Pipeline.hs:(721,22)-(722,42)    0.6    1.2
replaceMoreRestrictiveSubExpr' G2.Equiv.Tactics       src/G2/Equiv/Tactics.hs:(973,1)-(1001,22)              0.6    2.3
modifyChildren                 G2.Language.AST        src/G2/Language/AST.hs:(188,5)-(200,26)                0.5    1.4
passedArgs                     G2.Language.Typing     src/G2/Language/Typing.hs:222:1-34                     0.5    1.1
```
and after changes:
```
	total time  =       54.30 secs   (54295 ticks @ 1000 us, 1 processor)
	total alloc = 107,816,931,832 bytes  (excludes profiling overheads)

COST CENTRE                    MODULE                 SRC                                                  %time %alloc

moreRestrictive                G2.Equiv.Tactics       src/G2/Equiv/Tactics.hs:(202,1)-(346,16)              11.4    5.3
lookupConcOrSym                G2.Language.ExprEnv    src/G2/Language/ExprEnv.hs:(160,1)-(165,26)            7.3    1.9
hashWithSalt                   G2.Language.Syntax     src/G2/Language/Syntax.hs:(50,5)-(53,26)               5.0    1.9
tc_rn_src_decls                GHC.Tc.Module          compiler/GHC/Tc/Module.hs:(608,4)-(679,7)              4.8    4.8
member                         Data.HashSet.Internal  Data/HashSet/Internal.hs:(348,1)-(350,30)              4.1    0.0
Parser                         GHC.Driver.Main        compiler/GHC/Driver/Main.hs:(421,26)-(507,30)          4.0   10.9
deSugar                        GHC.Driver.Main        compiler/GHC/Driver/Main.hs:689:7-44                   3.7    5.7
modifyChildrenM                G2.Language.Monad.AST  src/G2/Language/Monad/AST.hs:(39,5)-(65,34)            2.9    4.9
hashWithSalt1                  Data.Hashable.Class    src/Data/Hashable/Class.hs:278:1-45                    2.8    2.0
hash                           G2.Language.Syntax     src/G2/Language/Syntax.hs:49:10-22                     2.6    1.8
getPreprocessedImports         GHC.Driver.Make        compiler/GHC/Driver/Make.hs:(2114,1)-(2128,33)         2.1    3.5
modifyChildren                 G2.Language.AST        src/G2/Language/AST.hs:(210,5)-(215,26)                1.9    6.9
modifyContainedASTsM           G2.Language.Monad.AST  src/G2/Language/Monad/AST.hs:(172,5)-(174,25)          1.7    2.3
hash                           Data.HashMap.Internal  Data/HashMap/Internal.hs:180:1-28                      1.6    0.0
simplIdF                       GHC.Core.Opt.Simplify  compiler/GHC/Core/Opt/Simplify.hs:1146:61-79           1.6    2.4
passedArgs'                    G2.Language.Typing     src/G2/Language/Typing.hs:(225,1)-(226,18)             1.3    2.3
appTypeOf                      G2.Language.Typing     src/G2/Language/Typing.hs:(233,1)-(247,79)             1.2    0.9
modify.go                      G2.Language.AST        src/G2/Language/AST.hs:53:9-40                         1.2    0.1
==                             G2.Language.Syntax     src/G2/Language/Syntax.hs:42:5-67                      1.1    0.0
unApp'                         G2.Language.Expr       src/G2/Language/Expr.hs:(127,1)-(128,18)               0.9    2.2
occAnalBind.assoc              GHC.Core.Opt.OccurAnal compiler/GHC/Core/Opt/OccurAnal.hs:821:13-64           0.8    1.6
simplTopBinds-simpl_binds      GHC.Core.Opt.Simplify  compiler/GHC/Core/Opt/Simplify.hs:221:68-90            0.8    1.1
replaceMoreRestrictiveSubExpr' G2.Equiv.Tactics       src/G2/Equiv/Tactics.hs:(977,1)-(1005,22)              0.7    2.4
byteCodeGen                    GHC.StgToByteCode      compiler/GHC/StgToByteCode.hs:(103,1)-(148,38)         0.6    1.5
OccAnal                        GHC.Core.Opt.Pipeline  compiler/GHC/Core/Opt/Pipeline.hs:(721,22)-(722,42)    0.6    1.2
passedArgs                     G2.Language.Typing     src/G2/Language/Typing.hs:222:1-34                     0.5    1.2
modifyChildren                 G2.Language.AST        src/G2/Language/AST.hs:(188,5)-(200,26)                0.5    1.5
```