### PR TITLE
Method name for higher-order symbolic function nrpc changed

### DIFF
--- a/src/G2/Config/Config.hs
+++ b/src/G2/Config/Config.hs
@@ -45,7 +45,7 @@ data SearchStrategy = Iterative | Subpath deriving (Eq, Show, Read)
 data HigherOrderSolver = AllFuncs
                        | SingleFunc
                        | SymbolicFunc 
-                       | SymbolicFuncTemplate deriving (Eq, Show, Read)
+                       | SymbolicFuncNRPC deriving (Eq, Show, Read)
 
 data NonRedPathCons = Nrpc | NoNrpc deriving (Eq, Show, Read)
 
@@ -156,7 +156,7 @@ mkHigherOrder =
                                     "all" -> Right AllFuncs
                                     "single" -> Right SingleFunc
                                     "symbolic" -> Right SymbolicFunc
-                                    "symbolic-temp" -> Right SymbolicFuncTemplate
+                                    "symbolic-nrpc" -> Right SymbolicFuncNRPC
                                     _ -> Left "Unsupported higher order function handling"))
             ( long "higher-order"
             <> metavar "HANDLING"

--- a/src/G2/Execution/Reducer.hs
+++ b/src/G2/Execution/Reducer.hs
@@ -51,7 +51,7 @@ module G2.Execution.Reducer ( Reducer (..)
                             , liftSomeReducer
 
                             , stdRed
-                            , nonRedPCTemplates
+                            , nonRedPCSymFuncRed
                             , nonRedLibFuncsReducer
                             , nonRedPCRed
                             , nonRedPCRedConst
@@ -482,12 +482,12 @@ stdRed share symb_func_eval solver simplifier =
                         )
 
 -- | Pushes non_red_path_conds onto the exec_stack for solving higher order symbolic function 
-nonRedPCTemplates :: Monad m => Reducer m () t
-nonRedPCTemplates = mkSimpleReducer (\_ -> ())
-                        nonRedPCTemplatesFunc
+nonRedPCSymFuncRed :: Monad m => Reducer m () t
+nonRedPCSymFuncRed = mkSimpleReducer (\_ -> ())
+                        nonRedPCSymFunc
 
-nonRedPCTemplatesFunc :: Monad m => RedRules m () t
-nonRedPCTemplatesFunc _
+nonRedPCSymFunc :: Monad m => RedRules m () t
+nonRedPCSymFunc _
                       s@(State { expr_env = eenv
                          , curr_expr = cexpr
                          , exec_stack = stck
@@ -505,7 +505,7 @@ nonRedPCTemplatesFunc _
             let 
                 s'' = s' {curr_expr = CurrExpr Evaluate nre1}
             in return (InProgress, [(s'', ())], b)
-nonRedPCTemplatesFunc _ s b = return (Finished, [(s, ())], b)
+nonRedPCSymFunc _ s b = return (Finished, [(s, ())], b)
 
 -- | A reducer to add library functions in non reduced path constraints for solving later  
 nonRedLibFuncsReducer :: Monad m => HS.HashSet Name -> Reducer m () t

--- a/src/G2/Interface/Interface.hs
+++ b/src/G2/Interface/Interface.hs
@@ -318,8 +318,8 @@ initRedHaltOrd mod_name solver simplifier config libFunNames =
             ( logger_std_red retReplaceSymbFuncTemplate .== Finished .--> SomeReducer nonRedPCRed
              , SomeHalter halter
              , orderer)
-        SymbolicFuncTemplate ->
-            ( logger_std_red retReplaceSymbFuncVar .== Finished .--> taggerRed state_name :== Finished --> nonRedPCTemplates
+        SymbolicFuncNRPC ->
+            ( logger_std_red retReplaceSymbFuncVar .== Finished .--> taggerRed state_name :== Finished --> nonRedPCSymFuncRed
              , SomeHalter (discardIfAcceptedTagHalter state_name <~> halter)
              , orderer)
 

--- a/tests/InputOutputTest.hs
+++ b/tests/InputOutputTest.hs
@@ -43,7 +43,7 @@ checkInputOutputsTemplate src tests = do
 checkInputOutputsNonRedTemp :: FilePath -> [(String, Int, [Reqs String])] -> TestTree
 checkInputOutputsNonRedTemp src tests = do
     checkInputOutput'
-        (do config <- mkConfigTestIO; return (config { higherOrderSolver = SymbolicFuncTemplate }))
+        (do config <- mkConfigTestIO; return (config { higherOrderSolver = SymbolicFuncNRPC }))
         src
         tests
 


### PR DESCRIPTION
Just changed the method name to avoid confusion for higher order symbolic function using nrpc