### PR TITLE
Analysis

### DIFF
--- a/g2.cabal
+++ b/g2.cabal
@@ -272,7 +272,7 @@ executable G2
   default-language:    Haskell2010
   ghc-options:         -threaded -Wall
                        -- -fexternal-interpreter -opti+RTS -opti-p
-  -- ghc-prof-options:    -fprof-auto "-with-rtsopts=-p"
+  ghc-prof-options:    -fprof-auto "-with-rtsopts=-p"
   hs-source-dirs:      exe
   main-is:             Main.hs
 

--- a/g2.cabal
+++ b/g2.cabal
@@ -252,7 +252,7 @@ library
                        -- -ddump-rule-rewrites
                        -- -ddump-splices
                        -- -fexternal-interpreter
-  -- ghc-prof-options:    -fprof-auto
+  ghc-prof-options:    -fprof-auto
   other-extensions:    CPP
   if flag(support-lh) && impl(ghc < 9)
     cpp-options: -DSUPPORT_LH
@@ -372,7 +372,7 @@ test-suite test
                        , RewriteVerify.RewriteVerifyTest
   ghc-options:         -Wall
                        -threaded
-  -- ghc-prof-options:    -fprof-auto "-with-rtsopts=-p"
+  ghc-prof-options:    -fprof-auto "-with-rtsopts=-p"
   type:                exitcode-stdio-1.0
 
 test-suite test-lh

--- a/g2.cabal
+++ b/g2.cabal
@@ -252,7 +252,7 @@ library
                        -- -ddump-rule-rewrites
                        -- -ddump-splices
                        -- -fexternal-interpreter
-  ghc-prof-options:    -fprof-auto
+  -- ghc-prof-options:    -fprof-auto
   other-extensions:    CPP
   if flag(support-lh) && impl(ghc < 9)
     cpp-options: -DSUPPORT_LH
@@ -272,7 +272,7 @@ executable G2
   default-language:    Haskell2010
   ghc-options:         -threaded -Wall
                        -- -fexternal-interpreter -opti+RTS -opti-p
-  ghc-prof-options:    -fprof-auto "-with-rtsopts=-p"
+  -- ghc-prof-options:    -fprof-auto "-with-rtsopts=-p"
   hs-source-dirs:      exe
   main-is:             Main.hs
 
@@ -372,7 +372,7 @@ test-suite test
                        , RewriteVerify.RewriteVerifyTest
   ghc-options:         -Wall
                        -threaded
-  ghc-prof-options:    -fprof-auto "-with-rtsopts=-p"
+  -- ghc-prof-options:    -fprof-auto "-with-rtsopts=-p"
   type:                exitcode-stdio-1.0
 
 test-suite test-lh

--- a/src/G2/Config/Config.hs
+++ b/src/G2/Config/Config.hs
@@ -87,6 +87,7 @@ data Config = Config {
     , step_limit :: Bool -- ^ Should steps be limited when running states?
     , steps :: Int -- ^ How many steps to take when running States
     , accept_times :: Bool -- ^ Output the time each state is accepted
+    , states_at_time :: Bool -- ^ Output time and number of states each time a state is added/removed
     , hpc :: Bool -- ^ Should HPC ticks be generated and tracked during execution?
     , hpc_print_times :: Bool -- ^ Print the time each HPC tick is reached?
     , strict :: Bool -- ^ Should the function output be strictly evaluated?
@@ -139,6 +140,7 @@ mkConfig homedir = Config Regular
                    <> value 1000
                    <> help "how many steps to take when running states")
     <*> switch (long "accept-times" <> help "output the time each state is accepted")
+    <*> switch (long "states-at-time" <> help "output time and number of states each time a state is added/removed")
     <*> flag False True (long "hpc"
                       <> help "Generate and report on HPC ticks")
     <*> switch (long "hpc-print-times" <> help "Print the time each HPC tick is reached?")
@@ -268,6 +270,7 @@ mkConfigDirect homedir as m = Config {
     , step_limit = boolArg' "no-step-limit" as True True False
     , steps = strArg "n" as m read 1000
     , accept_times = boolArg "accept-times" as m Off
+    , states_at_time = False
     , hpc = False
     , hpc_print_times = False
     , strict = boolArg "strict" as m On

--- a/src/G2/Config/Config.hs
+++ b/src/G2/Config/Config.hs
@@ -89,6 +89,7 @@ data Config = Config {
     , accept_times :: Bool -- ^ Output the time each state is accepted
     , states_at_time :: Bool -- ^ Output time and number of states each time a state is added/removed
     , states_at_step :: Bool -- ^ Output step and number of states at each step where a state is added/removed
+    , print_num_red_rules :: Bool -- ^ Output the total number of reduction rules
     , hpc :: Bool -- ^ Should HPC ticks be generated and tracked during execution?
     , hpc_print_times :: Bool -- ^ Print the time each HPC tick is reached?
     , strict :: Bool -- ^ Should the function output be strictly evaluated?
@@ -143,6 +144,7 @@ mkConfig homedir = Config Regular
     <*> switch (long "accept-times" <> help "output the time each state is accepted")
     <*> switch (long "states-at-time" <> help "output time and number of states each time a state is added/removed")
     <*> switch (long "states-at-step" <> help "output step and number of states at each step where a state is added/removed")
+    <*> switch (long "print-num-red-rules" <> help "output the total number of reduction rules")
     <*> flag False True (long "hpc"
                       <> help "Generate and report on HPC ticks")
     <*> switch (long "hpc-print-times" <> help "Print the time each HPC tick is reached?")
@@ -274,6 +276,7 @@ mkConfigDirect homedir as m = Config {
     , accept_times = boolArg "accept-times" as m Off
     , states_at_time = False
     , states_at_step = False
+    , print_num_red_rules = False
     , hpc = False
     , hpc_print_times = False
     , strict = boolArg "strict" as m On

--- a/src/G2/Config/Config.hs
+++ b/src/G2/Config/Config.hs
@@ -90,6 +90,7 @@ data Config = Config {
     , states_at_time :: Bool -- ^ Output time and number of states each time a state is added/removed
     , states_at_step :: Bool -- ^ Output step and number of states at each step where a state is added/removed
     , print_num_red_rules :: Bool -- ^ Output the total number of reduction rules
+    , print_nrpcs :: Bool -- ^ Output generated NRPCs
     , hpc :: Bool -- ^ Should HPC ticks be generated and tracked during execution?
     , hpc_print_times :: Bool -- ^ Print the time each HPC tick is reached?
     , strict :: Bool -- ^ Should the function output be strictly evaluated?
@@ -145,6 +146,7 @@ mkConfig homedir = Config Regular
     <*> switch (long "states-at-time" <> help "output time and number of states each time a state is added/removed")
     <*> switch (long "states-at-step" <> help "output step and number of states at each step where a state is added/removed")
     <*> switch (long "print-num-red-rules" <> help "output the total number of reduction rules")
+    <*> switch (long "print-nrpc" <> help "output generated nrpcs")
     <*> flag False True (long "hpc"
                       <> help "Generate and report on HPC ticks")
     <*> switch (long "hpc-print-times" <> help "Print the time each HPC tick is reached?")
@@ -277,6 +279,7 @@ mkConfigDirect homedir as m = Config {
     , states_at_time = False
     , states_at_step = False
     , print_num_red_rules = False
+    , print_nrpcs = False
     , hpc = False
     , hpc_print_times = False
     , strict = boolArg "strict" as m On

--- a/src/G2/Config/Config.hs
+++ b/src/G2/Config/Config.hs
@@ -88,6 +88,7 @@ data Config = Config {
     , steps :: Int -- ^ How many steps to take when running States
     , accept_times :: Bool -- ^ Output the time each state is accepted
     , states_at_time :: Bool -- ^ Output time and number of states each time a state is added/removed
+    , states_at_step :: Bool -- ^ Output step and number of states at each step where a state is added/removed
     , hpc :: Bool -- ^ Should HPC ticks be generated and tracked during execution?
     , hpc_print_times :: Bool -- ^ Print the time each HPC tick is reached?
     , strict :: Bool -- ^ Should the function output be strictly evaluated?
@@ -141,6 +142,7 @@ mkConfig homedir = Config Regular
                    <> help "how many steps to take when running states")
     <*> switch (long "accept-times" <> help "output the time each state is accepted")
     <*> switch (long "states-at-time" <> help "output time and number of states each time a state is added/removed")
+    <*> switch (long "states-at-step" <> help "output step and number of states at each step where a state is added/removed")
     <*> flag False True (long "hpc"
                       <> help "Generate and report on HPC ticks")
     <*> switch (long "hpc-print-times" <> help "Print the time each HPC tick is reached?")
@@ -271,6 +273,7 @@ mkConfigDirect homedir as m = Config {
     , steps = strArg "n" as m read 1000
     , accept_times = boolArg "accept-times" as m Off
     , states_at_time = False
+    , states_at_step = False
     , hpc = False
     , hpc_print_times = False
     , strict = boolArg "strict" as m On

--- a/src/G2/Equiv/G2Calls.hs
+++ b/src/G2/Equiv/G2Calls.hs
@@ -62,7 +62,7 @@ runG2ForNebula solver state h_opp track_opp config nc bindings = do
 
     (in_out, bindings') <- case rewriteRedHaltOrd solver simplifier h_opp track_opp config nc of
                 (red, hal, ord) ->
-                    SM.evalStateT (runG2WithSomes red hal ord solver simplifier sym_config state' bindings) (mkPrettyGuide ())
+                    SM.evalStateT (runG2WithSomes red hal ord noAnalysis solver simplifier sym_config state' bindings) (mkPrettyGuide ())
 
 
     return (in_out, bindings')

--- a/src/G2/Execution/Interface.hs
+++ b/src/G2/Execution/Interface.hs
@@ -12,11 +12,11 @@ import G2.Interface.ExecRes
 import G2.Language.Support
 
 {-# INLINE runExecutionToProcessed #-}
-runExecutionToProcessed :: (Monad m, Ord b) => Reducer m rv t -> Halter m hv r t -> Orderer m sov b r t -> (State t -> Bindings -> m (Maybe r)) -> State t -> Bindings -> m (Processed r (State t), Bindings)
+runExecutionToProcessed :: (Monad m, Ord b) => Reducer m rv t -> Halter m hv r t -> Orderer m sov b r t -> SolveStates m r t -> AnalyzeStates m r t -> State t -> Bindings -> m (Processed r (State t), Bindings)
 runExecutionToProcessed = runReducer
 
 {-# INLINE runExecution #-}
-runExecution :: (Monad m, Ord b) => Reducer m rv t -> Halter m hv r t -> Orderer m sov b r t -> (State t -> Bindings -> m (Maybe r)) -> State t -> Bindings -> m ([r], Bindings)
-runExecution r h ord solve_r s b = do
-    (pr, b') <- runReducer r h ord solve_r s b
+runExecution :: (Monad m, Ord b) => Reducer m rv t -> Halter m hv r t -> Orderer m sov b r t -> SolveStates m r t -> AnalyzeStates m r t -> State t -> Bindings -> m ([r], Bindings)
+runExecution r h ord solve_r analyze s b = do
+    (pr, b') <- runReducer r h ord solve_r analyze s b
     return (accepted pr, b')

--- a/src/G2/Execution/Interface.hs
+++ b/src/G2/Execution/Interface.hs
@@ -12,11 +12,11 @@ import G2.Interface.ExecRes
 import G2.Language.Support
 
 {-# INLINE runExecutionToProcessed #-}
-runExecutionToProcessed :: (Monad m, Ord b) => Reducer m rv t -> Halter m hv r t -> Orderer m sov b r t -> SolveStates m r t -> AnalyzeStates m r t -> State t -> Bindings -> m (Processed r (State t), Bindings)
+runExecutionToProcessed :: (Monad m, Ord b) => Reducer m rv t -> Halter m hv r t -> Orderer m sov b r t -> SolveStates m r t -> [AnalyzeStates m r t] -> State t -> Bindings -> m (Processed r (State t), Bindings)
 runExecutionToProcessed = runReducer
 
 {-# INLINE runExecution #-}
-runExecution :: (Monad m, Ord b) => Reducer m rv t -> Halter m hv r t -> Orderer m sov b r t -> SolveStates m r t -> AnalyzeStates m r t -> State t -> Bindings -> m ([r], Bindings)
+runExecution :: (Monad m, Ord b) => Reducer m rv t -> Halter m hv r t -> Orderer m sov b r t -> SolveStates m r t -> [AnalyzeStates m r t] -> State t -> Bindings -> m ([r], Bindings)
 runExecution r h ord solve_r analyze s b = do
     (pr, b') <- runReducer r h ord solve_r analyze s b
     return (accepted pr, b')

--- a/src/G2/Interface/Interface.hs
+++ b/src/G2/Interface/Interface.hs
@@ -461,8 +461,9 @@ runG2WithConfig entry_f mb_modname state@(State { expr_env = eenv }) config bind
 
     analysis1 <- if states_at_time config then do l <- logStatesAtTime; return [l] else return noAnalysis
     let analysis2 = if states_at_step config then [\s p xs -> SM.lift . SM.lift . SM.lift $ logStatesAtStep s p xs] else noAnalysis
-    let analysis3 = if print_num_red_rules config then [\s p xs -> SM.lift . SM.lift . SM.lift . SM.lift $ logRedRuleNum s p xs] else noAnalysis
-        analysis = analysis1 ++ analysis2 ++ analysis3
+        analysis3 = if print_num_red_rules config then [\s p xs -> SM.lift . SM.lift . SM.lift . SM.lift $ logRedRuleNum s p xs] else noAnalysis
+        analysis4 = if print_nrpcs config then [\s p xs -> SM.lift $ logNRPCs s p xs] else noAnalysis
+        analysis = analysis1 ++ analysis2 ++ analysis3 ++ analysis4
     
     (in_out, bindings') <- case null analysis of
         True -> do

--- a/src/G2/Interface/Interface.hs
+++ b/src/G2/Interface/Interface.hs
@@ -250,14 +250,14 @@ initCheckReaches s@(State { expr_env = eenv
                           , known_values = kv }) m_mod reaches =
     s {expr_env = checkReaches eenv kv reaches m_mod }
 
-type RHOStack m = SM.StateT LengthNTrack (SM.StateT PrettyGuide (SM.StateT HpcTracker m))
+type RHOStack m = SM.StateT LengthNTrack (SM.StateT PrettyGuide (SM.StateT HpcTracker (SM.StateT LogStatesAtStep m)))
 
 {-# SPECIALIZE runReducer :: Ord b =>
                              Reducer (RHOStack IO) rv ()
                           -> Halter (RHOStack IO) hv (ExecRes ()) ()
                           -> Orderer (RHOStack IO) sov b (ExecRes ()) ()
                           -> (State () -> Bindings -> RHOStack IO (Maybe (ExecRes ())))
-                          -> AnalyzeStates (RHOStack IO) (ExecRes ()) ()
+                          -> [AnalyzeStates (RHOStack IO) (ExecRes ()) ()]
                           -> State ()
                           -> Bindings
                           -> (RHOStack IO) (Processed (ExecRes ()) (State ()), Bindings)
@@ -460,20 +460,27 @@ runG2WithConfig entry_f mb_modname state@(State { expr_env = eenv }) config bind
                      $ E.filterConcOrSym (\case { E.Conc e -> not (reachesSymbolic S.empty eenv e); E.Sym _ -> False }) eenv
 
     rho <- initRedHaltOrd mod_name solver simplifier config not_symbolic (S.fromList executable_funcs) (S.fromList non_rec_funcs)
-    analysis <- if states_at_time config then logStatesAtTime else return noAnalysis 
+
+    analysis1 <- if states_at_time config then do l <- logStatesAtTime; return [l] else return noAnalysis
+    let analysis2 = if states_at_step config then [\s p xs -> SM.lift . SM.lift . SM.lift $ logStatesAtStep s p xs] else noAnalysis
+        analysis = analysis1 ++ analysis2
+    
     (in_out, bindings') <- case rho of
                 (red, hal, ord) ->
-                    SM.evalStateT
-                        (SM.evalStateT
+                    SM.evalStateT(
+                        SM.evalStateT
                             (SM.evalStateT
-                                (runG2WithSomes red hal ord analysis solver simplifier emptyMemConfig state bindings)
-                                lnt
+                                (SM.evalStateT
+                                    (runG2WithSomes red hal ord analysis solver simplifier emptyMemConfig state bindings)
+                                    lnt
+                                )
+                                (if showType config == Lax 
+                                then (mkPrettyGuide ())
+                                else setTypePrinting AggressiveTypes (mkPrettyGuide ())) 
                             )
-                           (if showType config == Lax 
-                            then (mkPrettyGuide ())
-                            else setTypePrinting AggressiveTypes (mkPrettyGuide ())) 
+                            hpc_t
                         )
-                        hpc_t
+                        logStatesAtStepTracker
 
     close solver
 
@@ -520,7 +527,7 @@ isFuncNonRecursive g n =
                 => SomeReducer (RHOStack IO) ()
                 -> SomeHalter (RHOStack IO) (ExecRes ()) ()
                 -> SomeOrderer (RHOStack IO) (ExecRes ()) ()
-                -> AnalyzeStates (RHOStack IO) (ExecRes ()) ()
+                -> [AnalyzeStates (RHOStack IO) (ExecRes ()) ()]
                 -> solver
                 -> simplifier
                 -> MemConfig
@@ -537,7 +544,7 @@ runG2WithSomes :: ( MonadIO m
                => SomeReducer m t
                -> SomeHalter m (ExecRes t) t
                -> SomeOrderer m (ExecRes t) t
-               -> AnalyzeStates m (ExecRes t) t
+               -> [AnalyzeStates m (ExecRes t) t]
                -> solver
                -> simplifier
                -> MemConfig
@@ -567,7 +574,7 @@ runG2Post :: ( MonadIO m
              , Ord b) => Reducer m rv t -> Halter m hv (ExecRes t) t -> Orderer m sov b (ExecRes t) t ->
              solver -> simplifier -> State t -> Bindings -> m ([ExecRes t], Bindings)
 runG2Post red hal ord solver simplifier is bindings = do
-    runExecution red hal ord (runG2Solving solver simplifier) noAnalysis is bindings
+    runExecution red hal ord (runG2Solving solver simplifier) [] is bindings
 
 runG2SolvingResult :: ( Named t
                       , Solver solver
@@ -643,7 +650,7 @@ runG2SubstModel m s@(State { type_env = tenv, known_values = kv }) bindings =
 {-# SPECIALIZE runG2 :: ( Solver solver
                         , Simplifier simplifier
                         , Ord b) => Reducer (RHOStack IO) rv () -> Halter (RHOStack IO) hv (ExecRes ()) () -> Orderer (RHOStack IO) sov b (ExecRes ()) () ->
-                        AnalyzeStates (RHOStack IO) (ExecRes ()) () ->
+                        [AnalyzeStates (RHOStack IO) (ExecRes ()) ()] ->
                         solver -> simplifier -> MemConfig -> State () -> Bindings -> RHOStack IO ([ExecRes ()], Bindings)
     #-}
 
@@ -656,7 +663,7 @@ runG2 :: ( MonadIO m
          , ASTContainer t Type
          , Solver solver
          , Simplifier simplifier
-         , Ord b) => Reducer m rv t -> Halter m hv (ExecRes t) t -> Orderer m sov b (ExecRes t) t -> AnalyzeStates m (ExecRes t) t ->
+         , Ord b) => Reducer m rv t -> Halter m hv (ExecRes t) t -> Orderer m sov b (ExecRes t) t -> [AnalyzeStates m (ExecRes t) t] ->
          solver -> simplifier -> MemConfig -> State t -> Bindings -> m ([ExecRes t], Bindings)
 runG2 red hal ord analyze solver simplifier mem is bindings = do
     let (is', bindings') = runG2Pre mem is bindings

--- a/src/G2/Lib/Printers.hs
+++ b/src/G2/Lib/Printers.hs
@@ -21,7 +21,8 @@ module G2.Lib.Printers ( PrettyGuide
 
                        , prettyState
                        , prettyEEnv
-                       , prettyTypeEnv 
+                       , prettyTypeEnv
+                       , prettyNonRedPaths
 
                        , prettyGuideStr
                        , prettyGuideNumsStr

--- a/src/G2/Liquid/G2Calls.hs
+++ b/src/G2/Liquid/G2Calls.hs
@@ -44,7 +44,7 @@ type G2Call solver simplifier =
                    , Named t
                    , ASTContainer t Expr
                    , ASTContainer t Type) =>
-        SomeReducer m t -> SomeHalter m (ExecRes t) t -> SomeOrderer m (ExecRes t) t -> solver -> simplifier -> MemConfig -> State t -> Bindings -> m ([ExecRes t], Bindings)
+        SomeReducer m t -> SomeHalter m (ExecRes t) t -> SomeOrderer m (ExecRes t) t -> [AnalyzeStates m (ExecRes t) t] -> solver -> simplifier -> MemConfig -> State t -> Bindings -> m ([ExecRes t], Bindings)
 
 -------------------------------
 -- Check Abstracted
@@ -132,6 +132,7 @@ checkAbstracted' g2call solver simplifier share s bindings abs_fc@(FuncCall { fu
                                 (SomeReducer (hitsLibError ~> stdRed share retReplaceSymbFuncVar solver simplifier ~> strictRed))
                                 (SomeHalter (swhnfHalter <~> acceptOnlyOneHalter <~> switchEveryNHalter 200))
                                 (SomeOrderer (incrAfterN 2000 (adtSizeOrderer 0 Nothing)))
+                                noAnalysis
                                 solver simplifier
                                 (emptyMemConfig { pres_func = \_ _ _ -> pres })
                                 s' bindings) (mkPrettyGuide pres)
@@ -186,6 +187,7 @@ getAbstracted g2call solver simplifier share s bindings abs_fc@(FuncCall { funcN
                                             --> (nonRedPCRedNoPrune .|. nonRedPCRedConst) ))
                               (SomeHalter (swhnfHalter <~> acceptOnlyOneHalter <~> switchEveryNHalter 200))
                               (SomeOrderer (incrAfterN 2000 (adtSizeOrderer 0 Nothing)))
+                              noAnalysis
                               solver simplifier
                               PreserveAllMC
                               s' bindings
@@ -423,6 +425,7 @@ reduceFCExpr g2call reducer solver simplifier s bindings e
                               reducer
                               (SomeHalter (acceptOnlyOneHalter <~> swhnfHalter <~> switchEveryNHalter 200))
                               (SomeOrderer (incrAfterN 2000 (adtSizeOrderer 0 Nothing)))
+                              noAnalysis
                               solver simplifier
                               PreserveAllMC
                               s' bindings

--- a/src/G2/Liquid/Inference/G2Calls.hs
+++ b/src/G2/Liquid/Inference/G2Calls.hs
@@ -175,7 +175,7 @@ runLHG2Inference config red hal ord solver simplifier pres_names init_id final_s
     (ret, final_bindings) <- case (red, hal, ord) of
                                 (SomeReducer red', SomeHalter hal', SomeOrderer ord') -> do
                                     let (s', b') = runG2Pre pres_names final_st bindings
-                                    runExecution red' hal' ord' (\s b -> return . Just $ earlyExecRes b s) s' b'
+                                    runExecution red' hal' ord' (\s b -> return . Just $ earlyExecRes b s) noAnalysis s' b'
     
     ret' <- filterM (satState solver . final_state) ret
     let ret'' = onlyMinimalStates ret'
@@ -242,12 +242,12 @@ runG2ThroughExecutionInference :: ( MonadIO m
                    , Named t
                    , ASTContainer t Expr
                    , ASTContainer t Type) =>
-        SomeReducer m t -> SomeHalter m (ExecRes t) t -> SomeOrderer m (ExecRes t) t -> solver -> simplifier -> MemConfig -> State t -> Bindings -> m ([ExecRes t], Bindings)
-runG2ThroughExecutionInference red hal ord _ _ pres s b = do
+        SomeReducer m t -> SomeHalter m (ExecRes t) t -> SomeOrderer m (ExecRes t) t -> [AnalyzeStates m (ExecRes t) t] -> solver -> simplifier -> MemConfig -> State t -> Bindings -> m ([ExecRes t], Bindings)
+runG2ThroughExecutionInference red hal ord _ _ _ pres s b = do
     case (red, hal, ord) of
             (SomeReducer red', SomeHalter hal', SomeOrderer ord') -> do
                     let (s', b') = runG2Pre pres s b
-                    runExecution red' hal' ord' (\s b -> return . Just $ earlyExecRes b s) s' b'
+                    runExecution red' hal' ord' (\s b -> return . Just $ earlyExecRes b s) noAnalysis s' b'
 
 runG2SolvingInference :: (MonadIO m, Solver solver, Simplifier simplifier) => solver -> simplifier -> Bindings -> ExecRes AbstractedInfo -> m (ExecRes AbstractedInfo)
 runG2SolvingInference solver simplifier bindings (ExecRes { final_state = s }) = do
@@ -367,7 +367,7 @@ gatherAllowedCalls entry m lrs ghci infconfig config lhconfig = do
                   , track = [] :: [FuncCall] }
 
     (red, hal, ord) <- gatherReducerHalterOrderer infconfig config' lhconfig solver simplifier
-    (exec_res, bindings'') <- SM.evalStateT (runG2WithSomes red hal ord solver simplifier pres_names s'' bindings') (mkPrettyGuide ())
+    (exec_res, bindings'') <- SM.evalStateT (runG2WithSomes red hal ord noAnalysis solver simplifier pres_names s'' bindings') (mkPrettyGuide ())
 
     putStrLn $ "length exec_res = " ++ show (length exec_res)
 
@@ -1087,6 +1087,7 @@ genericG2Call config solver s bindings = do
     fslb <- runG2WithSomes (SomeReducer (stdRed share retReplaceSymbFuncVar solver simplifier ~> strictRed))
                            (SomeHalter swhnfHalter)
                            (SomeOrderer nextOrderer)
+                           noAnalysis
                            solver simplifier PreserveAllMC s bindings
 
     return fslb
@@ -1110,6 +1111,7 @@ genericG2CallLogging config solver s bindings lg = do
     fslb <- runG2WithSomes (SomeReducer (prettyLogger lg ~> stdRed share retReplaceSymbFuncVar solver simplifier  ~> strictRed))
                            (SomeHalter swhnfHalter)
                            (SomeOrderer nextOrderer)
+                           noAnalysis
                            solver simplifier PreserveAllMC s bindings
 
     return fslb

--- a/src/G2/Liquid/Interface.hs
+++ b/src/G2/Liquid/Interface.hs
@@ -383,7 +383,7 @@ runLHG2 :: (MonadIO m, Solver solver, Simplifier simplifier)
         -> Bindings
         -> m ([ExecRes AbstractedInfo], Bindings)
 runLHG2 config red hal ord solver simplifier pres_names init_id final_st bindings = do
-    (ret, final_bindings) <- runG2WithSomes red hal ord solver simplifier pres_names final_st bindings
+    (ret, final_bindings) <- runG2WithSomes red hal ord noAnalysis solver simplifier pres_names final_st bindings
 
     let ret' = onlyMinimalStates ret
 

--- a/src/G2/QuasiQuotes/QuasiQuotes.hs
+++ b/src/G2/QuasiQuotes/QuasiQuotes.hs
@@ -238,7 +238,7 @@ runExecutionQ s b config = do
         (SomeReducer red, SomeHalter hal, SomeOrderer ord) -> do
             let (s'', b'') = runG2Pre emptyMemConfig s' b'
                 hal' = hal <~> zeroHalter 2000 <~> lemmingsHalter
-            (xs, b''') <- runExecutionToProcessed red hal' ord (\s b -> return $ Just s) s'' b''
+            (xs, b''') <- runExecutionToProcessed red hal' ord (\s b -> return $ Just s) noAnalysis s'' b''
 
             case xs of
                 Processed { accepted = acc, discarded = [] } -> do


### PR DESCRIPTION
Adding flags to print (1) number of states that exist at each time during execution (2) number of states that exist at each step count during execution (3) total number of reduction rules applied at the end of execution (across all states) (4) each generated NRPC, as it is added to a state.
Adds a general framework to the reducer to make it easier to add more such flags.