### PR TITLE
Updated exec/skip rules with memoization of variables

### DIFF
--- a/src/G2/Execution/ExecSkip.hs
+++ b/src/G2/Execution/ExecSkip.hs
@@ -49,7 +49,7 @@ checkDelayability' eenv e exec_names ng
         do
             currMemoTable <- SM.get
             case HM.lookup n currMemoTable of
-                Just value | Just ex_sk <- isSkippable n value ng eenv -> return ex_sk
+                Just value | Just ex_sk <- isSkippable n value eenv -> return (ex_sk, ng)
                 -- Rule-VAR
                 _ | Just e' <- E.lookup n eenv -> do
                     -- If we have recursive let bindings then we keep variable as skip to avoid infinite loop
@@ -114,13 +114,13 @@ checkDelayability' eenv e exec_names ng
     | otherwise = return (Skip, ng)
 
     where
-        isSkippable :: Name -> (ExecOrSkip, IsSWHNF) -> NameGen -> ExprEnv -> Maybe (ExecOrSkip, NameGen)
-        isSkippable _ (Skip, _) ng' _ = Just (Skip, ng')
-        isSkippable _ (Exec, IsSWHNF) ng' _ = Just (Exec, ng')
-        isSkippable var_name (Exec, NotIsSWHNF) _ eenv'
+        isSkippable :: Name -> (ExecOrSkip, IsSWHNF) -> ExprEnv -> Maybe ExecOrSkip
+        isSkippable _ (Skip, _) _ = Just Skip
+        isSkippable _ (Exec, IsSWHNF) _ = Just Exec
+        isSkippable var_name (Exec, NotIsSWHNF) eenv'
             | Just expr' <- E.lookup var_name eenv'
             , normalForm eenv expr' = Nothing
-        isSkippable _ _ ng' _ =  Just (Exec, ng')
+        isSkippable _ _ _ =  Just Exec
 
         getSWHNFStatus eenv' e' = if normalForm eenv' e' then IsSWHNF else NotIsSWHNF
 

--- a/src/G2/Execution/ExecSkip.hs
+++ b/src/G2/Execution/ExecSkip.hs
@@ -22,10 +22,14 @@ data ExecOrSkip = Exec
                 deriving (Eq, Show)
 
 
-isExecOrSkip :: ExecOrSkip -> ExecOrSkip -> ExecOrSkip
-isExecOrSkip Skip Skip = Skip
-isExecOrSkip Exec _ = Exec
-isExecOrSkip _ Exec = Exec
+isExecOrSkip :: SM.MonadState NRPCMemoTable m => NameGen -> (NameGen -> m (ExecOrSkip, NameGen)) -> (NameGen -> m (ExecOrSkip, NameGen)) -> m (ExecOrSkip, NameGen)
+isExecOrSkip ng f1 f2 =
+    do
+        (res1, ng') <- f1 ng
+        case res1 of
+            Exec -> return (Exec, ng')
+            Skip -> f2 ng'
+
 
 data IsSWHNF = IsSWHNF | NotIsSWHNF deriving (Show)
 type NRPCMemoTable = HM.HashMap Name (ExecOrSkip, IsSWHNF)
@@ -33,25 +37,26 @@ type NRPCMemoTable = HM.HashMap Name (ExecOrSkip, IsSWHNF)
 checkDelayability :: ExprEnv -> Expr -> NameGen -> HS.HashSet Name -> NRPCMemoTable -> (ExecOrSkip, NRPCMemoTable)
 checkDelayability eenv e ng exec_names table = 
     let 
-        ((res, _), var_table) = SM.runState (checkDelayability' eenv e ng exec_names ) table 
+        ((res, _), var_table) = SM.runState (checkDelayability' eenv e exec_names ng) table 
     in (res, var_table)
 
-checkDelayability' :: SM.MonadState NRPCMemoTable m => ExprEnv -> Expr -> NameGen -> HS.HashSet Name -> m (ExecOrSkip, NameGen)
-checkDelayability' eenv e ng exec_names
+checkDelayability' :: SM.MonadState NRPCMemoTable m => ExprEnv -> Expr -> HS.HashSet Name -> NameGen -> m (ExecOrSkip, NameGen)
+checkDelayability' eenv e exec_names ng
+    -- Rule-VAR-EXEC
+    | Var (Id n _) <- e
+    , True <- HS.member n exec_names = return (Exec, ng)
     | Var (Id n _) <- e =
         do
             currMemoTable <- SM.get
             case HM.lookup n currMemoTable of
-                Just value -> isSkippable e value ng eenv
-                -- Rule-VAR-EXEC
-                Nothing | True <- HS.member n exec_names -> return (Exec, ng)
+                Just value | Just ex_sk <- isSkippable n value ng eenv -> return ex_sk
                 -- Rule-VAR
-                Nothing | Just e' <- E.lookup n eenv -> do 
-                    let var_table_update = HM.insert n (Skip, NotIsSWHNF) currMemoTable
-                    SM.put var_table_update
-                    (res, ng') <- checkDelayability' eenv e' ng exec_names
-                    let var_table_update' = HM.insert n (res, getSWHNFStatus eenv e') currMemoTable
-                    SM.put var_table_update'
+                _ | Just e' <- E.lookup n eenv -> do
+                    -- If we have recursive let bindings then we keep variable as skip to avoid infinite loop
+                    -- and check delayability of the mapped expression. Now, we can update variable's exact delayability.
+                    SM.modify (HM.insert n (Skip, NotIsSWHNF))
+                    (res, ng') <- checkDelayability' eenv e' exec_names ng
+                    SM.modify (HM.insert n (res, getSWHNFStatus eenv e'))
                     return (res, ng')
                 -- Rule-SYM-VAR, that decides for any variable that's not in heap, be it let bindings or symbolic variable
                 Nothing -> return (Skip, ng)
@@ -72,7 +77,7 @@ checkDelayability' eenv e ng exec_names
 
             eenv' = E.insertExprs (zip news binds_rhs') eenv
 
-        in checkDelayability' eenv' e'' ng' exec_names
+        in checkDelayability' eenv' e'' exec_names ng'
     -- Rule-LAM
     | Lam _ i e1 <- e = 
         let
@@ -80,7 +85,7 @@ checkDelayability' eenv e ng exec_names
             (x', ng') = freshSeededName old ng
             e1' = renameExpr old x' e1
         in
-            checkDelayability' eenv e1' ng' exec_names
+            checkDelayability' eenv e1' exec_names ng'
     -- Rule-APP-LAM
     | App (Lam _ i e1) e2 <- e = 
         let
@@ -89,58 +94,39 @@ checkDelayability' eenv e ng exec_names
             e1' = renameExpr old x' e1
             eenv' = E.insert x' e2 eenv
         in 
-            checkDelayability' eenv' e1' ng' exec_names
+            checkDelayability' eenv' e1' exec_names ng'
     -- Rule-APP
-    | App e1 e2 <- e = 
-        do -- Question: Come back here and decide if we need to return name gen too?
-            (del_e1, ng') <- checkDelayability' eenv e1 ng exec_names
-            (del_e2, ng'') <- checkDelayability' eenv e2 ng' exec_names
-            return (isExecOrSkip del_e1 del_e2, ng'')
+    | App e1 e2 <- e = isExecOrSkip ng (checkDelayability' eenv e1 exec_names) (checkDelayability' eenv e2 exec_names)
     -- Rule-PRIM
-    | (Prim _ _):es <- unApp e = checklistOfExprs eenv es ng exec_names
+    | (Prim _ _):es <- unApp e = checklistOfExprs eenv es exec_names ng
     -- Rule for determining case statements
     | Case e' _ _ alts <- e = 
+    | Case e' _ _ alts <- e = 
         let altsExpr = e' : map (\(Alt _ e) -> e) alts
-        in checklistOfExprs eenv altsExpr ng exec_names
+        in checklistOfExprs eenv altsExpr exec_names ng
 
     | Type _ <- e = return (Skip, ng)
-    | Cast e' _ <- e = checkDelayability' eenv e' ng exec_names
-    | Tick _ e' <- e = checkDelayability' eenv e' ng exec_names
-    | NonDet es <- e = checklistOfExprs eenv es ng exec_names
+    | Cast e' _ <- e = checkDelayability' eenv e' exec_names ng
+    | Tick _ e' <- e = checkDelayability' eenv e' exec_names ng
+    | NonDet es <- e = checklistOfExprs eenv es exec_names ng
     | SymGen _ _ <- e = return (Skip, ng)
-    | Assume _ e1 e2 <- e = 
-        do
-            (del_e1, ng') <- checkDelayability' eenv e1 ng exec_names
-            (del_e2, ng'') <- checkDelayability' eenv e2 ng' exec_names
-            return (isExecOrSkip del_e1 del_e2, ng'')
-    | Assert _ e1 e2 <- e = 
-        do
-            (del_e1, ng') <- checkDelayability' eenv e1 ng exec_names
-            (del_e2, ng'') <- checkDelayability' eenv e2 ng' exec_names
-            return (isExecOrSkip del_e1 del_e2, ng'')
+    | Assume _ e1 e2 <- e = isExecOrSkip ng (checkDelayability' eenv e1 exec_names) (checkDelayability' eenv e2 exec_names)
+    | Assert _ e1 e2 <- e = isExecOrSkip ng (checkDelayability' eenv e1 exec_names) (checkDelayability' eenv e2 exec_names)
     | otherwise = return (Skip, ng)
 
     where
-        isSkippable _ (Skip, _) ng' _ = return (Skip, ng')
-        isSkippable _ (Exec, IsSWHNF) ng' _ = return (Exec, ng')
-        isSkippable (Var (Id n _)) (Exec, NotIsSWHNF) ng' eenv'
-            | Just expr' <- E.lookup n eenv'
-            , normalForm eenv expr' =
-                do
-                    (res, ng'') <- checkDelayability' eenv' expr' ng' exec_names
-                    curr_var_table <- SM.get
-                    let var_table_update = HM.insert n (res, IsSWHNF) curr_var_table
-                    SM.put var_table_update
-                    return (res, ng'')
-        isSkippable _ (Exec, NotIsSWHNF) ng' _ = return (Exec, ng')
+        isSkippable :: Name -> (ExecOrSkip, IsSWHNF) -> NameGen -> ExprEnv -> Maybe (ExecOrSkip, NameGen)
+        isSkippable _ (Skip, _) ng' _ = Just (Skip, ng')
+        isSkippable _ (Exec, IsSWHNF) ng' _ = Just (Exec, ng')
+        isSkippable var_name (Exec, NotIsSWHNF) _ eenv'
+            | Just expr' <- E.lookup var_name eenv'
+            , normalForm eenv expr' = Nothing
+        isSkippable _ _ ng' _ =  Just (Exec, ng')
 
         getSWHNFStatus eenv' e' = if normalForm eenv' e' then IsSWHNF else NotIsSWHNF
 
 
-checklistOfExprs :: SM.MonadState NRPCMemoTable m => ExprEnv -> [Expr] -> NameGen -> HS.HashSet Name -> m (ExecOrSkip, NameGen)
-checklistOfExprs _ [] ng _ = return (Skip, ng)
-checklistOfExprs eenv (e : es) ng exec_names = 
-    do
-        (del_e, ng') <- checkDelayability' eenv e ng exec_names
-        (del_es, ng'') <- checklistOfExprs eenv es ng' exec_names
-        return (isExecOrSkip del_e del_es, ng'')
+checklistOfExprs :: SM.MonadState NRPCMemoTable m => ExprEnv -> [Expr] -> HS.HashSet Name -> NameGen -> m (ExecOrSkip, NameGen)
+checklistOfExprs _ [] _ ng = return (Skip, ng)
+checklistOfExprs eenv (e : es) exec_names ng = 
+        isExecOrSkip ng (checkDelayability' eenv e exec_names) (checklistOfExprs eenv es exec_names)

--- a/src/G2/Execution/ExecSkip.hs
+++ b/src/G2/Execution/ExecSkip.hs
@@ -99,8 +99,7 @@ checkDelayability' eenv e exec_names ng
     | App e1 e2 <- e = isExecOrSkip ng (checkDelayability' eenv e1 exec_names) (checkDelayability' eenv e2 exec_names)
     -- Rule-PRIM
     | (Prim _ _):es <- unApp e = checklistOfExprs eenv es exec_names ng
-    -- Rule for determining case statements
-    | Case e' _ _ alts <- e = 
+    -- Rule for determining case statements 
     | Case e' _ _ alts <- e = 
         let altsExpr = e' : map (\(Alt _ e) -> e) alts
         in checklistOfExprs eenv altsExpr exec_names ng

--- a/src/G2/Execution/Reducer.hs
+++ b/src/G2/Execution/Reducer.hs
@@ -604,11 +604,11 @@ nonRedLibFuncsReducer :: MonadIO m =>
                                          -- I.e. if `f` is in this set, `f x y` will not be added to the NRPCs, but a function `g` that includes
                                          -- `f in it's definition may still be added to the NRPCs.
                       -> Config
-                      -> Reducer m Int t
+                      -> Reducer m (NRPCMemoTable, Int) t
 nonRedLibFuncsReducer not_symbolic exec_names no_nrpc_names config =
-    (mkSimpleReducer (\_ -> 0)
+    (mkSimpleReducer (\_ -> (HM.empty, 0))
         (nonRedLibFuncs not_symbolic exec_names no_nrpc_names (symbolic_func_nrpc config)))
-        { onAccept = \s b nrpc_count -> do
+        { onAccept = \s b (_, nrpc_count) -> do
             if print_num_nrpc config
                 then liftIO . putStrLn $ "NRPCs Generated: " ++ show nrpc_count
                 else return ()
@@ -619,17 +619,18 @@ nonRedLibFuncs :: Monad m => HS.HashSet Name -- ^ Names of variables that defini
                           -> HS.HashSet Name -- ^ Names of functions that should not reesult in a larger expression become EXEC,
                                              -- but should not be added to the NRPC at the top level.
                           -> Bool -- ^ Use NRPCs to delay execution of symbolic functions
-                          -> RedRules m Int t
-nonRedLibFuncs not_symbolic exec_names no_nrpc_names use_with_symb_func nrpc_count
+                          -> RedRules m (NRPCMemoTable, Int) t
+nonRedLibFuncs not_symbolic exec_names no_nrpc_names use_with_symb_func 
+                (var_table, nrpc_count)
                 s@(State { expr_env = eenv
                          , curr_expr = CurrExpr _ ce
                          , type_env = tenv
                          , known_values = kv
                          , non_red_path_conds = nrs
                          }) 
-                         b@(Bindings { name_gen = ng })
+                b@(Bindings { name_gen = ng })
     | Var (Id n t):es <- unApp ce
-    , not (n `HS.member` no_nrpc_names)
+    --, not (n `HS.member` no_nrpc_names)
     , use_with_symb_func || (E.isSymbolic n eenv)
     , hasFuncType (PresType t)
     -- We want to introduce an NRPC only if the function is fully applied and does not have nested function argument types
@@ -640,7 +641,7 @@ nonRedLibFuncs not_symbolic exec_names no_nrpc_names use_with_symb_func nrpc_cou
     -- (for instance, MutVars, Handles) into NRPC symbolic variables.
     , not (hasMagicTypes ce)
     , reachesSymbolic not_symbolic eenv ce
-    , Skip <- canAddToNRPC eenv ce ng exec_names HS.empty
+    , (Skip, var_table') <- checkDelayability eenv ce ng exec_names var_table
     = 
         let
             (new_sym, ng') = freshSeededString "sym" ng
@@ -658,9 +659,9 @@ nonRedLibFuncs not_symbolic exec_names no_nrpc_names use_with_symb_func nrpc_cou
             curr_expr = cexpr',
             non_red_path_conds = (ce', Var new_sym_id):nrs } 
         in 
-            return (Finished, [(s', nrpc_count + 1)], b {name_gen = ng'})
+            return (Finished, [(s', (var_table', nrpc_count + 1))], b {name_gen = ng'})
 
-    | otherwise = return (Finished, [(s, nrpc_count)], b)
+    | otherwise = return (Finished, [(s, (var_table, nrpc_count + 1))], b)
     where
         digNewType (TyCon n _) | Just (NewTyCon { rep_type = rt }) <- HM.lookup n tenv = digNewType rt
         digNewType (TyApp t1 t2) = digNewType t1

--- a/tests/BaseTests/ListTests.hs
+++ b/tests/BaseTests/ListTests.hs
@@ -61,7 +61,7 @@ fibonacci :: [Int]
 fibonacci = let fibs = 0 : 1 : zipWith (+) fibs (tail fibs)  
             in fibs
 
-testFib :: Bool
-testFib = case length (take 3 fibonacci) of
+testFib :: Int -> Bool
+testFib n = case length (take n fibonacci) of
         3 -> True
         _ -> False

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -375,7 +375,7 @@ testFileTests = testGroup "TestFiles"
                                                                      , ("multiPrim", 300, [Exactly 2])]
     , checkInputOutputsNonRedLib "tests/BaseTests/ListTests.hs" [ ("lengthN", 800, [AtLeast 5])
                                                                 , ("map2", 150, [AtLeast 2])
-                                                                , ("testFib", 1300, [AtLeast 1])]
+                                                                , ("testFib", 300, [AtLeast 1])]
                                                                 
     , checkInputOutputsNonRedLib "tests/TestFiles/NRPC/EmptyTuple.hs" [ ("main", 1000, [AtLeast 1])]
     , checkExprNRPC "tests/TestFiles/NRPC/Print.hs" 2500 "f" [AtLeast 5]

--- a/tests/scripts/nofib-buggy.py
+++ b/tests/scripts/nofib-buggy.py
@@ -22,7 +22,7 @@ def call_g2_process(filename, func, var_settings):
 
 def run_nofib_bench(filename, var_settings, timeout):
     # --check-asserts --error-asserts --accept-times --print-num-nrpc --no-step-limit --search subpath --time 60
-    return run_g2(filename, "main", ["--check-asserts", "--error-asserts", "--accept-times", "--print-num-nrpc", "--no-step-limit", "--search", "subpath", "--time", str(timeout)] + var_settings)
+    return run_g2(filename, "main", ["--check-asserts", "--error-asserts", "--accept-times", "--print-num-nrpc", "--print-num-red-rules", "--no-step-limit", "--search", "subpath", "--time", str(timeout)] + var_settings)
 
 def run_nofib_bench_nrpc(filename, var_settings, timeout):
     return run_nofib_bench(filename, ["--nrpc", "--higher-order", "symbolic"] + var_settings, timeout)
@@ -32,10 +32,15 @@ def process_output(out):
     nrpcs_num = list(map(lambda x : int(x), nrpcs))
     reached = re.findall(r"State Accepted: ((?:\d|\.|e|-)*)", out)
     reached_time = list(map(lambda x : float(x), reached))
+    red_rules = re.search(r"# Red Rules: ((?:\d)*)", out)
+    red_rules_num = 0
+    if red_rules:
+        red_rules_num = int(red_rules.group(1))
     out = reached_time
     if len(nrpcs_num) == len(reached_time):
         out = list(zip(nrpcs_num, reached_time))
     print(out)
+    print(red_rules_num)
 
 # Read in the types of bugs
 def read_bug_types(setpath):


### PR DESCRIPTION
Added memoization logic to keep track of vars and it's delayability.
Update runG2 such that some functions that perform sweeping mechanism can be performed before calling G2 to improve efficiency of call graph method.
And updated the nofib-buggy script to keep reduction rules count.