### PR TITLE
Easy funcs

### DIFF
--- a/base_setup.sh
+++ b/base_setup.sh
@@ -1,4 +1,4 @@
-base_commit=3056255
+base_commit=606f8cb
 stubs_commit=db1e16c
 
 get_base() {

--- a/src/G2/Execution/InstTypes.hs
+++ b/src/G2/Execution/InstTypes.hs
@@ -68,8 +68,8 @@ instType' (ng, st) i
     | otherwise = (ng, st)
         
 -- define a new reducer that calls your instType on your onAccept function
-instTypeRed :: (ASTContainer t Type, Monad m) => Reducer m () t
+instTypeRed :: (ASTContainer t Type, Monad m) => Reducer m () r t
 instTypeRed  = (mkSimpleReducer
                         (\_ -> ())
-                        (\rv s b -> return (NoProgress, [(s , rv)], b)) )
+                        (\rv _ s b -> return (NoProgress, [(s , rv)], b)) )
                         {onAccept = \s b _ -> return (instType s b)} 

--- a/src/G2/Execution/Interface.hs
+++ b/src/G2/Execution/Interface.hs
@@ -12,11 +12,11 @@ import G2.Interface.ExecRes
 import G2.Language.Support
 
 {-# INLINE runExecutionToProcessed #-}
-runExecutionToProcessed :: (Monad m, Ord b) => Reducer m rv t -> Halter m hv r t -> Orderer m sov b r t -> SolveStates m r t -> [AnalyzeStates m r t] -> State t -> Bindings -> m (Processed r (State t), Bindings)
+runExecutionToProcessed :: (Monad m, Ord b) => Reducer m rv r t -> Halter m hv r t -> Orderer m sov b r t -> SolveStates m r t -> [AnalyzeStates m r t] -> State t -> Bindings -> m (Processed r (State t), Bindings)
 runExecutionToProcessed = runReducer
 
 {-# INLINE runExecution #-}
-runExecution :: (Monad m, Ord b) => Reducer m rv t -> Halter m hv r t -> Orderer m sov b r t -> SolveStates m r t -> [AnalyzeStates m r t] -> State t -> Bindings -> m ([r], Bindings)
+runExecution :: (Monad m, Ord b) => Reducer m rv r t -> Halter m hv r t -> Orderer m sov b r t -> SolveStates m r t -> [AnalyzeStates m r t] -> State t -> Bindings -> m ([r], Bindings)
 runExecution r h ord solve_r analyze s b = do
     (pr, b') <- runReducer r h ord solve_r analyze s b
     return (accepted pr, b')

--- a/src/G2/Execution/Rules.hs
+++ b/src/G2/Execution/Rules.hs
@@ -1265,11 +1265,10 @@ easyScrutinee tenv eenv = getAll . go HS.empty
                              | Just e <- E.lookup n eenv = go (HS.insert n ns) e
                              | otherwise = All False
         go ns (Tick _ e) = go ns e
-        go ns (App e1 _) = go ns e1
+        go ns (App e1 e2) = go ns e1 <> go ns e2
         go _ (Data _) = All True
-        go _ (Lit _) = All True
         go _ (Type _) = All True
-        go _ e = All False
+        go _ _ = All False
         
         -- Recursive types must eventually be able to hit func-const
         nonRecType ns (TyCon n _)

--- a/src/G2/Execution/Rules.hs
+++ b/src/G2/Execution/Rules.hs
@@ -1265,8 +1265,10 @@ easyScrutinee tenv eenv = getAll . go HS.empty
                              | Just e <- E.lookup n eenv = go (HS.insert n ns) e
                              | otherwise = All False
         go ns (Tick _ e) = go ns e
-        go ns (App e1 e2) = go ns e1 <> go ns e2
+        go ns (App e1 _) = go ns e1
         go _ (Data _) = All True
+        go _ (Lit _) = All True
+        go _ (Type _) = All True
         go _ e = All False
         
         -- Recursive types must eventually be able to hit func-const
@@ -1275,6 +1277,7 @@ easyScrutinee tenv eenv = getAll . go HS.empty
             | Just (DataTyCon { data_cons = [dc] }) <- HM.lookup n tenv =
                             all (nonRecType (HS.insert n ns)) $ argumentTypes dc
             | otherwise = False
+        nonRecType ns (TyApp t1 t2) = nonRecType ns t1 && nonRecType ns t2
         nonRecType _ TYPE = True
         nonRecType _ t | isPrimType t = True
         nonRecType _ _ = False

--- a/src/G2/Execution/Rules.hs
+++ b/src/G2/Execution/Rules.hs
@@ -21,8 +21,7 @@ module G2.Execution.Rules ( module G2.Execution.RuleTypes
                           , SymbolicFuncEval
                           , retReplaceSymbFuncVar
                           , retReplaceSymbFuncTemplate
-                          , retReplaceSymbFuncTemplateConst
-                          , retReplaceSymbFuncTemplateNonConst) where
+                          , retReplaceSymbFuncTemplateFavorNonConst) where
 
 import G2.Config.Config
 import G2.Execution.DataConPCMap
@@ -1166,10 +1165,16 @@ type SymbolicFuncEval t = State t -> NameGen -> Expr -> Maybe ([State t], NameGe
 
 
 retReplaceSymbFuncTemplate :: State t -> NameGen -> Expr -> Maybe ([State t], NameGen)
-retReplaceSymbFuncTemplate s ng e = do
+retReplaceSymbFuncTemplate = retReplaceSymbFuncTemplate' (++)
+
+retReplaceSymbFuncTemplateFavorNonConst :: State t -> NameGen -> Expr -> Maybe ([State t], NameGen)
+retReplaceSymbFuncTemplateFavorNonConst = retReplaceSymbFuncTemplate' (flip (++))
+
+retReplaceSymbFuncTemplate' :: ([State t] -> [State t] -> [State t]) -> State t -> NameGen -> Expr -> Maybe ([State t], NameGen)
+retReplaceSymbFuncTemplate' comb s ng e = do
     (xs, ng') <- retReplaceSymbFuncTemplateNonConst s ng e
     let xs_ng = retReplaceSymbFuncTemplateConst s ng' e
-        (final_xs, final_ng) = maybe (xs, ng') (first (++ xs)) xs_ng
+        (final_xs, final_ng) = maybe (xs, ng') (first (`comb` xs)) xs_ng
     return (final_xs, final_ng)
 
 retReplaceSymbFuncTemplateConst :: State t -> NameGen -> Expr -> Maybe ([State t], NameGen)

--- a/src/G2/QuasiQuotes/QuasiQuotes.hs
+++ b/src/G2/QuasiQuotes/QuasiQuotes.hs
@@ -271,7 +271,7 @@ moduleName = "THTemp"
 functionName :: String
 functionName = "g2Expr"
 
-qqRedHaltOrd :: (MonadIO m, Solver solver, Simplifier simplifier) => Config -> solver -> simplifier -> (SomeReducer m (), SomeHalter m r (), SomeOrderer m r ())
+qqRedHaltOrd :: (MonadIO m, Solver solver, Simplifier simplifier) => Config -> solver -> simplifier -> (SomeReducer m r (), SomeHalter m r (), SomeOrderer m r ())
 qqRedHaltOrd config solver simplifier =
     let
         share = sharing config


### PR DESCRIPTION
Avoid instantiating symbolic functions to the constant function when instantiating via DC-SPLIT will (obviously) not result in an infinite loop/crash and will not cause state splits.