### PR TITLE
String pattern

### DIFF
--- a/base_setup.sh
+++ b/base_setup.sh
@@ -1,4 +1,4 @@
-base_commit=835f1bd
+base_commit=0fa894f
 stubs_commit=db1e16c
 
 get_base() {

--- a/base_setup.sh
+++ b/base_setup.sh
@@ -1,4 +1,4 @@
-base_commit=aebcaa8
+base_commit=f644c5b
 stubs_commit=db1e16c
 
 get_base() {

--- a/base_setup.sh
+++ b/base_setup.sh
@@ -1,4 +1,4 @@
-base_commit=0fa894f
+base_commit=aebcaa8
 stubs_commit=db1e16c
 
 get_base() {

--- a/base_setup.sh
+++ b/base_setup.sh
@@ -1,4 +1,4 @@
-base_commit=f644c5b
+base_commit=12b402c
 stubs_commit=db1e16c
 
 get_base() {

--- a/src/G2/Execution/RuleTypes.hs
+++ b/src/G2/Execution/RuleTypes.hs
@@ -23,6 +23,9 @@ data Rule = RuleEvalVal
           | RuleEvalApp Expr
 
           | RuleEvalPrimAlreadyNorm
+          | RuleEvalPrimFloatTicks
+          | RuleEvalPrimToNormWithState
+          | RuleEvalPrimToNormSymbolic
           | RuleEvalPrimToNorm
 
           | RuleEvalLet [Name]

--- a/src/G2/Execution/Rules.hs
+++ b/src/G2/Execution/Rules.hs
@@ -166,10 +166,10 @@ evalApp s@(State { expr_env = eenv
     , ts <- concatMap getTickish es
     , not (null ts) =
         let e = foldr Tick (stripAllTicks (App e1 e2)) ts in
-        (RuleEvalPrimToNorm, [ (newPCEmpty $ s { curr_expr = CurrExpr Evaluate e })], ng)
-    | Just (new_pc, ng') <- evalPrimWithState s ng (stripAllTicks $ App e1 e2) = (RuleEvalPrimToNorm, [new_pc], ng')
+        (RuleEvalPrimFloatTicks, [ (newPCEmpty $ s { curr_expr = CurrExpr Evaluate e })], ng)
+    | Just (new_pc, ng') <- evalPrimWithState s ng (stripAllTicks $ App e1 e2) = (RuleEvalPrimToNormWithState, [new_pc], ng')
     | Just (e, eenv', pc, ng') <- evalPrimSymbolic eenv tenv ng kv (App e1 e2) =
-        ( RuleEvalPrimToNorm
+        ( RuleEvalPrimToNormSymbolic
         , [ (newPCEmpty $ s { expr_env = eenv'
                             , curr_expr = CurrExpr Evaluate e }) { new_pcs = pc} ]
         , ng')

--- a/src/G2/Initialization/Interface.hs
+++ b/src/G2/Initialization/Interface.hs
@@ -8,6 +8,7 @@ import G2.Language.Expr
 import G2.Language.KnownValues
 import G2.Language.Syntax
 import G2.Language.Support hiding (State (..))
+import G2.Language.Typing
 import G2.Initialization.ElimTicks
 import G2.Initialization.ElimTypeSynonyms
 import G2.Initialization.FpToRational
@@ -38,13 +39,18 @@ runInitialization2 config s@(IT.SimpleState { IT.expr_env = eenv
         eenv4 = if error_asserts config then assertFalseOnError kv eenv3 else eenv3
 
         t = Id (Name "t" Nothing 0 Nothing) TYPE
+        str = Id (Name "s" Nothing 0 Nothing) (tyString kv)
         x = Id (Name "x" Nothing 0 Nothing) TyLitInt
         eenv5 = if smt_strings config == NoSMTStrings
                         then E.insert (typeIndex kv) 
                                       (Lam TypeL t . Lam TermL x . Lit $ LitInt 0) eenv4
                         else eenv4
+        eenv6 = if smt_strings config == NoSMTStrings
+                        then E.insert (adjStr kv) 
+                                      (Lam TypeL t . Lam TermL x . Lam TermL str $ Var x) eenv5
+                        else eenv5
 
-        s' = s { IT.expr_env = eenv5
+        s' = s { IT.expr_env = eenv6
                , IT.type_env = tenv2
                , IT.name_gen = ng2
                , IT.handles = hs

--- a/src/G2/Initialization/KnownValues.hs
+++ b/src/G2/Initialization/KnownValues.hs
@@ -121,6 +121,7 @@ initKnownValues eenv tenv tc =
     , notFunc = exprWithStrName eenv "not"
 
     , typeIndex = exprWithStrName eenv "typeIndex#"
+    , adjStr = exprWithStrName eenv "adjStr"
 
     , errorFunc = exprWithStrName eenv "error"
     , errorEmptyListFunc = exprWithStrName eenv "errorEmptyList"

--- a/src/G2/Interface/Interface.hs
+++ b/src/G2/Interface/Interface.hs
@@ -695,7 +695,7 @@ runG2SubstModel :: Named t =>
                    -> State t
                    -> Bindings
                    -> ExecRes t
-runG2SubstModel m s@(State { type_env = tenv, known_values = kv }) bindings =
+runG2SubstModel m s@(State { expr_env = eenv, type_env = tenv, known_values = kv }) bindings =
     let
         s' = s { model = m }
 
@@ -717,12 +717,12 @@ runG2SubstModel m s@(State { type_env = tenv, known_values = kv }) bindings =
         sm' = runPostprocessing bindings sm
 
         sm'' = ExecRes { final_state = final_state sm'
-                       , conc_args = fixed_inputs bindings ++ evalPrims tenv kv (conc_args sm')
-                       , conc_out = evalPrims tenv kv (conc_out sm')
+                       , conc_args = fixed_inputs bindings ++ evalPrims eenv tenv kv (conc_args sm')
+                       , conc_out = evalPrims eenv tenv kv (conc_out sm')
                        , conc_sym_gens = gens
                        , conc_mutvars = mv
                        , conc_handles = conc_handles sm'
-                       , violated = evalPrims tenv kv (violated sm')}
+                       , violated = evalPrims eenv tenv kv (violated sm')}
     in
     sm''
 

--- a/src/G2/Language/Arbitrary.hs
+++ b/src/G2/Language/Arbitrary.hs
@@ -430,6 +430,7 @@ fakeKnownValues =
     , notFunc = Name "" Nothing 0 Nothing
 
     , typeIndex = Name "" Nothing 0 Nothing
+    , adjStr = Name "" Nothing 0 Nothing
 
     , errorFunc = Name "" Nothing 0 Nothing
     , errorWithoutStackTraceFunc = Name "" Nothing 0 Nothing

--- a/src/G2/Language/ExprEnv.hs
+++ b/src/G2/Language/ExprEnv.hs
@@ -21,6 +21,7 @@ module G2.Language.ExprEnv
     , lookupEnvObj
     , deepLookup
     , deepLookupExpr
+    , deepLookupConcOrSym
     , isSymbolic
     , occLookup
     , lookupNameMod
@@ -178,6 +179,14 @@ deepLookup n eenv =
 deepLookupExpr :: Expr -> ExprEnv -> Maybe Expr
 deepLookupExpr (Var (Id n _)) eenv = deepLookup n eenv
 deepLookupExpr e _  = Just e
+
+deepLookupConcOrSym :: Name -> ExprEnv -> Maybe ConcOrSym
+deepLookupConcOrSym n eenv =
+    case lookupConcOrSym n eenv of
+        Just (Conc (Var (Id n' _))) -> deepLookupConcOrSym n' eenv
+        Just c@(Conc r) -> Just c
+        Just s@(Sym r) -> Just s
+        Nothing -> Nothing
 
 -- | Checks if the given `Name` belongs to a symbolic variable.
 isSymbolic :: Name -> ExprEnv -> Bool

--- a/src/G2/Language/KnownValues.hs
+++ b/src/G2/Language/KnownValues.hs
@@ -105,6 +105,7 @@ data KnownValues = KnownValues {
                  , notFunc :: Name
 
                  , typeIndex :: Name
+                 , adjStr :: Name
 
                  -- Useful functions
                  , errorFunc :: Name

--- a/src/G2/Language/Naming.hs
+++ b/src/G2/Language/Naming.hs
@@ -628,6 +628,7 @@ instance Named KnownValues where
             , notFunc = notF
 
             , typeIndex = ti
+            , adjStr = adjN
 
             , errorFunc = errF
             , errorEmptyListFunc = errEmpListF
@@ -649,7 +650,7 @@ instance Named KnownValues where
                 , geF, gtF, ltF, leF
                 , impF, iffF
                 , andF, orF, notF
-                , ti
+                , ti, adjN
                 , errF, errEmpListF, errWOST, patE]
 
     rename old new (KnownValues {
@@ -737,6 +738,7 @@ instance Named KnownValues where
                    , notFunc = notF
 
                    , typeIndex = ti
+                   , adjStr = adjN
 
                    , errorFunc = errF
                    , errorEmptyListFunc = errEmpListF
@@ -828,6 +830,7 @@ instance Named KnownValues where
                         , notFunc = rename old new notF
 
                         , typeIndex = rename old new ti
+                        , adjStr = rename old new adjN
 
                         , errorFunc = rename old new errF
                         , errorEmptyListFunc = rename old new errEmpListF

--- a/src/G2/Language/Syntax.hs
+++ b/src/G2/Language/Syntax.hs
@@ -267,7 +267,7 @@ data Primitive = -- Mathematical and logical operators
                | WriteMutVar -- ^ `forall d a. MutVar# d a -> a -> State# d -> State# d`.
 
                -- True if passed a symbolic variable, false otherwise
-               | IsSymbolic
+               | IsSMTRep
 
                -- TypeIndex maps types to Int#s:
                -- 1: String

--- a/src/G2/Language/Syntax.hs
+++ b/src/G2/Language/Syntax.hs
@@ -266,7 +266,7 @@ data Primitive = -- Mathematical and logical operators
                | ReadMutVar -- ^ `forall d a. MutVar# d a -> State# d -> a`.
                | WriteMutVar -- ^ `forall d a. MutVar# d a -> a -> State# d -> State# d`.
 
-               -- True if passed a symbolic variable, false otherwise
+               -- True if passed an expression that can be converted into an SMT formula, false otherwise
                | IsSMTRep
 
                -- TypeIndex maps types to Int#s:

--- a/src/G2/Language/Syntax.hs
+++ b/src/G2/Language/Syntax.hs
@@ -266,6 +266,9 @@ data Primitive = -- Mathematical and logical operators
                | ReadMutVar -- ^ `forall d a. MutVar# d a -> State# d -> a`.
                | WriteMutVar -- ^ `forall d a. MutVar# d a -> a -> State# d -> State# d`.
 
+               -- True if passed a symbolic variable, false otherwise
+               | IsSymbolic
+
                -- TypeIndex maps types to Int#s:
                -- 1: String
                -- 0: Any other type

--- a/src/G2/Lib/Printers.hs
+++ b/src/G2/Lib/Printers.hs
@@ -476,6 +476,8 @@ mkPrimHaskell pg = pr
         pr Iff = "pr_iff"
         pr Ite = "pr_ite"
 
+        pr IsSymbolic = "isSymbolic"
+
         pr TypeIndex = "typeIndex"
 
         pr UnspecifiedOutput = "?"

--- a/src/G2/Lib/Printers.hs
+++ b/src/G2/Lib/Printers.hs
@@ -476,7 +476,7 @@ mkPrimHaskell pg = pr
         pr Iff = "pr_iff"
         pr Ite = "pr_ite"
 
-        pr IsSymbolic = "isSymbolic"
+        pr IsSMTRep = "isSMTRep"
 
         pr TypeIndex = "typeIndex"
 

--- a/src/G2/Liquid/Inference/G2Calls.hs
+++ b/src/G2/Liquid/Inference/G2Calls.hs
@@ -202,7 +202,7 @@ cleanupResultsInference solver simplifier config init_id bindings ers = do
           map (\er@(ExecRes { final_state = s }) ->
                 (er { final_state =
                               s {track = 
-                                    mapAbstractedInfoFCs (evalPrims (type_env s) (known_values s)
+                                    mapAbstractedInfoFCs (evalPrims (expr_env s) (type_env s) (known_values s)
                                                          . subVarFuncCall True (model s) (expr_env s) (type_classes s))
                                     $ track s
                                 }

--- a/src/G2/QuasiQuotes/FloodConsts.hs
+++ b/src/G2/QuasiQuotes/FloodConsts.hs
@@ -16,7 +16,7 @@ floodConstantsChecking :: [(Name, Expr)] -> State t -> Maybe (State t)
 floodConstantsChecking ne s =
     case floodConstants ne s of
         Just s' ->
-            if all (pathCondMaybeSatisfiable (type_env s') (known_values s'))
+            if all (pathCondMaybeSatisfiable (expr_env s') (type_env s') (known_values s'))
                    (PC.toList $ path_conds s')
                 then Just s'
                 else Nothing
@@ -58,17 +58,17 @@ floodConstantList _ _ = Nothing
 -- Attempts to determine if a PathCond is satisfiable.  A return value of False
 -- means the PathCond is definitely unsatisfiable.  A return value of True means
 -- the PathCond may or may not be satisfiable. 
-pathCondMaybeSatisfiable :: TypeEnv -> KnownValues -> PathCond -> Bool
-pathCondMaybeSatisfiable _ _ (AltCond l1 (Lit l2) b) = (l1 == l2) == b
-pathCondMaybeSatisfiable _ _ (AltCond _ _ _) = True
-pathCondMaybeSatisfiable tenv kv (ExtCond e b) =
+pathCondMaybeSatisfiable :: ExprEnv -> TypeEnv -> KnownValues -> PathCond -> Bool
+pathCondMaybeSatisfiable _ _ _ (AltCond l1 (Lit l2) b) = (l1 == l2) == b
+pathCondMaybeSatisfiable _ _ _ (AltCond _ _ _) = True
+pathCondMaybeSatisfiable eenv tenv kv (ExtCond e b) =
     let
-        r = evalPrims tenv kv e
+        r = evalPrims eenv tenv kv e
         
         tr = mkBool kv True
         fal = mkBool kv False
     in
     if (r == tr && not b) || (r == fal && b) then False else True
-pathCondMaybeSatisfiable _ _ (SoftPC _) = True
-pathCondMaybeSatisfiable _ _ (MinimizePC _) = True
-pathCondMaybeSatisfiable tenv kv (AssumePC _ _ hs) = any (pathCondMaybeSatisfiable tenv kv . PC.unhashedPC) hs
+pathCondMaybeSatisfiable _ _ _ (SoftPC _) = True
+pathCondMaybeSatisfiable _ _ _ (MinimizePC _) = True
+pathCondMaybeSatisfiable eenv tenv kv (AssumePC _ _ hs) = any (pathCondMaybeSatisfiable eenv tenv kv . PC.unhashedPC) hs

--- a/src/G2/Translation/PrimInject.hs
+++ b/src/G2/Translation/PrimInject.hs
@@ -218,6 +218,7 @@ primDefs' b c l unit =
               , ("ratioZeroDenominatorError", Prim Error TyBottom)
               , ("undefined", Prim Error TyBottom)
               
+              , ("isSymbolic#", Prim IsSymbolic (TyForAll a (TyFun (TyVar a) (TyCon b TYPE))))
               , ("typeIndex#", Prim TypeIndex (TyForAll a (TyFun (TyVar a) TyLitInt))) ]
               where
                     strTy = (TyApp (TyCon l (TyFun TYPE TYPE)) (TyCon c TYPE))

--- a/src/G2/Translation/PrimInject.hs
+++ b/src/G2/Translation/PrimInject.hs
@@ -218,7 +218,7 @@ primDefs' b c l unit =
               , ("ratioZeroDenominatorError", Prim Error TyBottom)
               , ("undefined", Prim Error TyBottom)
               
-              , ("isSymbolic#", Prim IsSymbolic (TyForAll a (TyFun (TyVar a) (TyCon b TYPE))))
+              , ("isSMTRep#", Prim IsSMTRep (TyForAll a (TyFun (TyVar a) (TyCon b TYPE))))
               , ("typeIndex#", Prim TypeIndex (TyForAll a (TyFun (TyVar a) TyLitInt))) ]
               where
                     strTy = (TyApp (TyCon l (TyFun TYPE TYPE)) (TyCon c TYPE))

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -358,7 +358,7 @@ testFileTests = testGroup "TestFiles"
                                         , ("taker1", 1000, [Exactly 3])
                                         , ("taker2", 1000, [Exactly 3])
                                         , ("conTaker1", 2500, [Exactly 4])
-                                        , ("conTaker2", 2500, [Exactly 3])
+                                        , ("conTaker2", 2500, [Exactly 2])
                                         , ("lengthCon1", 2500, [Exactly 2])
                                         , ("conIndex1", 2500, [AtLeast 2])
                                         , ("eq1", 1000, [Exactly 2])

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -357,8 +357,13 @@ testFileTests = testGroup "TestFiles"
                                         , ("strIndex", 1000, [Exactly 4]) 
                                         , ("taker1", 1000, [Exactly 3])
                                         , ("taker2", 1000, [Exactly 3])
+                                        , ("conTaker1", 2500, [AtLeast 4])
+                                        , ("conTaker2", 2500, [Exactly 3])
+                                        , ("lengthCon1", 2500, [Exactly 2])
+                                        , ("conIndex1", 2500, [AtLeast 2])
                                         , ("eq1", 1000, [Exactly 2])
-                                        , ("eq2", 1000, [Exactly 2])]
+                                        , ("eq2", 1000, [Exactly 2])
+                                        , ("eq3", 2500, [AtLeast 2])]
 
     , checkExpr "tests/TestFiles/Strings/Strings1.hs" 1000 "exclaimEq"
         [AtLeast 5, RExists (\[_, _, r] -> dcHasName "True" r)]

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -357,13 +357,13 @@ testFileTests = testGroup "TestFiles"
                                         , ("strIndex", 1000, [Exactly 4]) 
                                         , ("taker1", 1000, [Exactly 3])
                                         , ("taker2", 1000, [Exactly 3])
-                                        , ("conTaker1", 2500, [AtLeast 4])
+                                        , ("conTaker1", 2500, [Exactly 4])
                                         , ("conTaker2", 2500, [Exactly 3])
                                         , ("lengthCon1", 2500, [Exactly 2])
                                         , ("conIndex1", 2500, [AtLeast 2])
                                         , ("eq1", 1000, [Exactly 2])
                                         , ("eq2", 1000, [Exactly 2])
-                                        , ("eq3", 2500, [AtLeast 2])]
+                                        , ("eq3", 2500, [Exactly 2])]
 
     , checkExpr "tests/TestFiles/Strings/Strings1.hs" 1000 "exclaimEq"
         [AtLeast 5, RExists (\[_, _, r] -> dcHasName "True" r)]

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -336,7 +336,7 @@ testFileTests = testGroup "TestFiles"
 
     , checkExprAssume "tests/TestFiles/Subseq.hs" 1200 (Just "assume") "subseqTest" [AtLeast 1]
 
-    , checkInputOutputs "tests/TestFiles/Strings/Strings1.hs" [ ("con", 300, [AtLeast 10])
+    , checkInputOutputs "tests/TestFiles/Strings/Strings1.hs" [ ("con", 400, [AtLeast 10])
                                                               , ("eq", 700, [AtLeast 10])
                                                               , ("eqGt1", 700, [AtLeast 10])
                                                               , ("capABC", 100, [AtLeast 10])
@@ -355,15 +355,15 @@ testFileTests = testGroup "TestFiles"
                                         , ("strLen", 1000, [Exactly 2])
                                         , ("con2", 1000, [Exactly 3])
                                         , ("strIndex", 1000, [Exactly 4]) 
-                                        , ("taker1", 1000, [Exactly 3])
-                                        , ("taker2", 1000, [Exactly 3])
+                                        , ("taker1", 5000, [Exactly 2])
+                                        , ("taker2", 5000, [Exactly 2])
                                         , ("conTaker1", 2500, [Exactly 4])
                                         , ("conTaker2", 2500, [Exactly 2])
                                         , ("lengthCon1", 2500, [Exactly 2])
                                         , ("conIndex1", 2500, [AtLeast 2])
-                                        , ("eq1", 1000, [Exactly 2])
-                                        , ("eq2", 1000, [Exactly 2])
-                                        , ("eq3", 2500, [Exactly 2])]
+                                        , ("eq1", 5000, [Exactly 2])
+                                        , ("eq2", 5000, [Exactly 2])
+                                        , ("eq3", 5000, [Exactly 2])]
 
     , checkExpr "tests/TestFiles/Strings/Strings1.hs" 1000 "exclaimEq"
         [AtLeast 5, RExists (\[_, _, r] -> dcHasName "True" r)]

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -347,14 +347,18 @@ testFileTests = testGroup "TestFiles"
                                                               , ("nStringSub3", 2000, [AtLeast 15])
                                                               , ("stringSub4", 7000, [AtLeast 7])
                                                               , ("nStringSub4", 2000, [AtLeast 5])
-                                                              , ("strLen", 1000, [AtLeast 5]) ]
+                                                              , ("strLen", 1000, [AtLeast 5])
+                                                              , ("taker2", 2000, [AtLeast 5]) ]
     , checkInputOutputsSMTStrings "tests/TestFiles/Strings/Strings1.hs"
                                         [ ("con", 1000, [Exactly 1])
                                         , ("appendEq", 1000, [Exactly 1])
                                         , ("strLen", 1000, [Exactly 2])
                                         , ("con2", 1000, [Exactly 3])
                                         , ("strIndex", 1000, [Exactly 4]) 
-                                        , ("eq1", 1000, [Exactly 2])]
+                                        , ("taker1", 1000, [Exactly 3])
+                                        , ("taker2", 1000, [Exactly 3])
+                                        , ("eq1", 1000, [Exactly 2])
+                                        , ("eq2", 1000, [Exactly 2])]
 
     , checkExpr "tests/TestFiles/Strings/Strings1.hs" 1000 "exclaimEq"
         [AtLeast 5, RExists (\[_, _, r] -> dcHasName "True" r)]

--- a/tests/TestFiles/Strings/Strings1.hs
+++ b/tests/TestFiles/Strings/Strings1.hs
@@ -73,7 +73,7 @@ taker1 str = case take 30 str of
 
 taker2 :: String -> (Bool, String)
 taker2 str = case take 22 str of
-                x@"HelloHelloHelloHelloHe" -> (True, x)
+                x@"Hi" -> (True, x)
                 y -> (False, y)
 
 -- For smt strings, needs a fairly long string for speedup here

--- a/tests/TestFiles/Strings/Strings1.hs
+++ b/tests/TestFiles/Strings/Strings1.hs
@@ -66,10 +66,15 @@ strIndex str =
         '2' -> (False, "Two")
         _ -> (False, "None")
 
-taker :: String -> (Bool, String)
-taker str = case take 30 str of
-                "HelloHelloHelloHelloHelloHello" -> error "aaa"
-                _ -> (True, "abcde")
+taker1 :: String -> (Bool, String)
+taker1 str = case take 30 str of
+                x@"HelloHelloHelloHelloHelloHello" -> (True, x)
+                y -> (False, y)
+
+taker2 :: String -> (Bool, String)
+taker2 str = case take 22 str of
+                x@"HelloHelloHelloHelloHe" -> (True, x)
+                y -> (False, y)
 
 -- For smt strings, needs a fairly long string for speedup here
 eq1 :: String -> Int
@@ -77,3 +82,7 @@ eq1 s = case "123456789019234623479629031641906590659651902651908560189893412572
             True -> 1
             _ -> 0
 
+eq2 :: String -> Int
+eq2 s = case s of
+            "123456789019234623479629031641906590659651902651908560189893412572348901572902834752389057389057890345789037529803" -> 1
+            _ -> 0

--- a/tests/TestFiles/Strings/Strings1.hs
+++ b/tests/TestFiles/Strings/Strings1.hs
@@ -76,6 +76,27 @@ taker2 str = case take 22 str of
                 x@"Hi" -> (True, x)
                 y -> (False, y)
 
+conTaker1 :: String -> String -> (Int, String)
+conTaker1 xs ys =
+    case take 18 xs ++ take 18 ys of
+        zs@"It was a dark and stormy night" | length xs < length ys -> (1, zs)
+                                            | length xs > 18 -> (2, zs)
+                                            | otherwise -> (3, zs)
+        zs -> (4, zs)
+
+conTaker2 :: String -> String -> (Int, String)
+conTaker2 xs ys =
+    case take 10 (xs ++ ys) of
+        zs@"HelloHello" -> (1, zs)
+        zs -> (2, zs)
+
+lengthCon1 :: String -> (Int, Bool)
+lengthCon1 xs = let z = length (xs ++ "!!!") in (z, case z > 5 of True -> False; False -> True)
+
+conIndex1 :: Int -> String -> (Int, Char)
+conIndex1 n xs | 10 <= n, n < 20, length xs > 10 = (n, (xs ++ xs) !! n)
+               | otherwise = (n, (xs ++ xs) !! n)
+
 -- For smt strings, needs a fairly long string for speedup here
 eq1 :: String -> Int
 eq1 s = case "123456789019234623479629031641906590659651902651908560189893412572348901572902834752389057389057890345789037529803" == s of
@@ -86,3 +107,8 @@ eq2 :: String -> Int
 eq2 s = case s of
             "123456789019234623479629031641906590659651902651908560189893412572348901572902834752389057389057890345789037529803" -> 1
             _ -> 0
+
+eq3 :: String -> String -> Int
+eq3 s1 s2 = case "123456789 123456789 123456789" == s1 ++ s2 of
+                        True -> 1
+                        False -> 0


### PR DESCRIPTION
Adjusting String SMT primitives to force evaluation of arguments so that we can handle expressions with nested primitive string operators. Is careful to avoid unnecessary concretization of String symbolic variables/primitives.

Corresponding base changes:
https://github.com/BillHallahan/base-4.9.1.0/pull/4