### PR TITLE
SMT String implementations of elem, notElem, isInfixOf, and elemIndex

### DIFF
--- a/base_setup.sh
+++ b/base_setup.sh
@@ -1,4 +1,4 @@
-base_commit=11b355f 
+base_commit=6a61e93
 stubs_commit=db1e16c
 
 get_base() {

--- a/base_setup.sh
+++ b/base_setup.sh
@@ -1,4 +1,4 @@
-base_commit=07cb8c8 
+base_commit=38a66a8 
 stubs_commit=db1e16c
 
 get_base() {

--- a/base_setup.sh
+++ b/base_setup.sh
@@ -1,4 +1,4 @@
-base_commit=6a61e93
+base_commit=a9bccf2
 stubs_commit=db1e16c
 
 get_base() {

--- a/base_setup.sh
+++ b/base_setup.sh
@@ -1,4 +1,4 @@
-base_commit=38a66a8 
+base_commit=11b355f 
 stubs_commit=db1e16c
 
 get_base() {

--- a/src/G2/Language/Syntax.hs
+++ b/src/G2/Language/Syntax.hs
@@ -247,6 +247,7 @@ data Primitive = -- Mathematical and logical operators
                | StrAppend
                | StrAt
                | StrSubstr
+               | StrIndexOf
                | Chr
                | OrdChar
                | WGenCat

--- a/src/G2/Lib/Printers.hs
+++ b/src/G2/Lib/Printers.hs
@@ -451,6 +451,7 @@ mkPrimHaskell pg = pr
         pr StrAppend = "StrAppend"
         pr StrAt = "str.at"
         pr StrSubstr = "str.substr"
+        pr StrIndexOf = "str.indexof"
         pr Chr = "chr"
         pr OrdChar = "ord"
 

--- a/src/G2/Solver/Converters.hs
+++ b/src/G2/Solver/Converters.hs
@@ -308,6 +308,7 @@ isStr' (_ `StrGeSMT` _) = All True
 isStr' (StrLenSMT _) = All True
 isStr' (_ :!! _) = All True
 isStr' (StrSubstrSMT _ _ _) = All True
+isStr' (StrIndexOfSMT _ _ _) = All True
 isStr' (FromCode _) = All True
 isStr' (ToCode _) = All True
 isStr' (VString _) = All True
@@ -529,6 +530,7 @@ funcToSMT3Prim :: Primitive -> Expr -> Expr -> Expr -> SMTAST
 funcToSMT3Prim Fp x y z = FpSMT  (exprToSMT x) (exprToSMT y) (exprToSMT z)
 funcToSMT3Prim Ite x y z = IteSMT (exprToSMT x) (exprToSMT y) (exprToSMT z)
 funcToSMT3Prim StrSubstr x y z = StrSubstrSMT (exprToSMT x) (exprToSMT y) (exprToSMT z)
+funcToSMT3Prim StrIndexOf x y z = StrIndexOfSMT (exprToSMT x) (exprToSMT y) (exprToSMT z)
 funcToSMT3Prim op _ _ _ = error $ "funcToSMT3Prim: invalid case with " ++ show op
 
 altToSMT :: Lit -> Expr -> SMTAST
@@ -704,6 +706,7 @@ toSolverAST (FromInt x) = function1 "str.from_int" $ toSolverAST x
 toSolverAST (StrLenSMT x) = function1 "str.len" $ toSolverAST x
 toSolverAST (x :!! y) = function2 "str.at" (toSolverAST x) (toSolverAST y)
 toSolverAST (StrSubstrSMT x y z) = function3 "str.substr" (toSolverAST x) (toSolverAST y) (toSolverAST z)
+toSolverAST (StrIndexOfSMT x y z) = function3 "str.indexof" (toSolverAST x) (toSolverAST y) (toSolverAST z)
 
 toSolverAST (IntToRealSMT x) = function1 "to_real" $ toSolverAST x
 toSolverAST (IntToFPSMT e s x) =

--- a/src/G2/Solver/Language.hs
+++ b/src/G2/Solver/Language.hs
@@ -120,6 +120,7 @@ data SMTAST = (:>=) !SMTAST !SMTAST
             | StrGeSMT !SMTAST !SMTAST
             | (:!!) !SMTAST !SMTAST -- ^ String index
             | StrSubstrSMT !SMTAST !SMTAST !SMTAST
+            | StrIndexOfSMT !SMTAST !SMTAST !SMTAST
 
             | IteSMT !SMTAST !SMTAST !SMTAST
             | SLet (SMTName, SMTAST) !SMTAST

--- a/src/G2/Translation/PrimInject.hs
+++ b/src/G2/Translation/PrimInject.hs
@@ -201,6 +201,14 @@ primDefs' b c l unit =
                                     (Prim Eq ((TyFun strTy) $ TyFun strTy (TyCon b TYPE)))
                                     (Var $ y strTy))
                                 (Var $ z strTy))
+              , ("strIndexOf#", Lam TypeL (x TYPE) . Lam TermL (y strTy) . Lam TermL (z TyLitInt) . Lam TermL ((dummyId "q") TyLitInt)
+                            $ App
+                                (App
+                                    (App
+                                        (Prim StrIndexOf (TyFun strTy (TyFun strTy (TyFun TyLitInt TyLitInt))))
+                                        (Var $ y strTy))
+                                    (Var $ z strTy))
+                                (Var $ (dummyId "q") TyLitInt))
               , ("intToString#", Prim IntToString (TyFun TyLitInt strTy))
 
               , ("newMutVar##", Prim NewMutVar (TyForAll a (TyForAll d (TyFun tyvarA (TyFun TyUnknown TyUnknown)))))

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -348,7 +348,10 @@ testFileTests = testGroup "TestFiles"
                                                               , ("stringSub4", 7000, [AtLeast 7])
                                                               , ("nStringSub4", 2000, [AtLeast 5])
                                                               , ("strLen", 1000, [AtLeast 5])
-                                                              , ("taker2", 2000, [AtLeast 5]) ]
+                                                              , ("taker2", 2000, [AtLeast 5]) 
+                                                              , ("infix1", 1000, [AtLeast 5])
+                                                              , ("elem1", 1000, [AtLeast 5])
+                                                              , ("notElem1", 1000, [AtLeast 5]) ]
     , checkInputOutputsSMTStrings "tests/TestFiles/Strings/Strings1.hs"
                                         [ ("con", 1000, [Exactly 1])
                                         , ("appendEq", 1000, [Exactly 1])
@@ -369,7 +372,10 @@ testFileTests = testGroup "TestFiles"
                                         , ("last1", 5000, [Exactly 4])
                                         , ("drop1", 5000, [Exactly 2])
                                         , ("drop2", 5000, [Exactly 2])
-                                        , ("drop3", 5000, [Exactly 3])]
+                                        , ("drop3", 5000, [Exactly 3])
+                                        , ("infix1", 5000, [Exactly 2])
+                                        , ("elem1", 5000, [Exactly 2])
+                                        , ("notElem1", 5000, [Exactly 4]) ]
 
     , checkExpr "tests/TestFiles/Strings/Strings1.hs" 1000 "exclaimEq"
         [AtLeast 5, RExists (\[_, _, r] -> dcHasName "True" r)]

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -351,7 +351,8 @@ testFileTests = testGroup "TestFiles"
                                                               , ("taker2", 2000, [AtLeast 5]) 
                                                               , ("infix1", 1000, [AtLeast 5])
                                                               , ("elem1", 1000, [AtLeast 5])
-                                                              , ("notElem1", 1000, [AtLeast 5]) ]
+                                                              , ("notElem1", 1000, [AtLeast 5])
+                                                              , ("elemIndex1", 1000, [AtLeast 5]) ]
     , checkInputOutputsSMTStrings "tests/TestFiles/Strings/Strings1.hs"
                                         [ ("con", 1000, [Exactly 1])
                                         , ("appendEq", 1000, [Exactly 1])
@@ -375,7 +376,8 @@ testFileTests = testGroup "TestFiles"
                                         , ("drop3", 5000, [Exactly 3])
                                         , ("infix1", 5000, [Exactly 2])
                                         , ("elem1", 5000, [Exactly 2])
-                                        , ("notElem1", 5000, [Exactly 4]) ]
+                                        , ("notElem1", 5000, [Exactly 4])
+                                        , ("elemIndex1", 5000, [Exactly 4]) ]
 
     , checkExpr "tests/TestFiles/Strings/Strings1.hs" 1000 "exclaimEq"
         [AtLeast 5, RExists (\[_, _, r] -> dcHasName "True" r)]

--- a/tests/TestFiles/Strings/Strings1.hs
+++ b/tests/TestFiles/Strings/Strings1.hs
@@ -167,3 +167,11 @@ infix1 :: String -> String -> Int
 infix1 needle haystack = case isInfixOf needle haystack of
                             True -> 1
                             False -> 42
+
+elemIndex1 :: Char -> String -> Int
+elemIndex1 c s
+            | pos == Just 1 = 1
+            | pos == Just 0 = 0
+            | pos == Nothing = -1
+            | otherwise = -2
+            where pos = elemIndex c s

--- a/tests/TestFiles/Strings/Strings1.hs
+++ b/tests/TestFiles/Strings/Strings1.hs
@@ -170,8 +170,8 @@ infix1 needle haystack = case isInfixOf needle haystack of
 
 elemIndex1 :: Char -> String -> Int
 elemIndex1 c s
-            | pos == Just 1 = 1
-            | pos == Just 0 = 0
+            | pos == (Just 1) = 1
+            | pos == (Just 0) = 0 
             | pos == Nothing = -1
             | otherwise = -2
             where pos = elemIndex c s

--- a/tests/TestFiles/Strings/Strings1.hs
+++ b/tests/TestFiles/Strings/Strings1.hs
@@ -148,3 +148,13 @@ drop3 str = case drop 20 str of
                 "" | length str /= 20 -> 1
                    | str /= "" -> 2
                 _ -> 3
+
+elem1 :: String -> Char -> (Bool, String)
+elem1 str ch = case elem ch str of
+                    True -> (False, "Switched")
+                    False -> (True, "Opposite Day!")
+
+infix1 :: String -> String -> Int
+infix1 needle haystack = case isInfixOf needle haystack of
+                            True -> 1
+                            False -> 42

--- a/tests/TestFiles/Strings/Strings1.hs
+++ b/tests/TestFiles/Strings/Strings1.hs
@@ -154,6 +154,15 @@ elem1 str ch = case elem ch str of
                     True -> (False, "Switched")
                     False -> (True, "Opposite Day!")
 
+notElem1 :: String -> Char -> Char -> String
+notElem1 str c1 c2 = case notElem c1 str of
+                            True -> case notElem c2 str of
+                                        True -> "None"
+                                        False -> "Second"
+                            False -> case notElem c2 str of
+                                        True -> "First"
+                                        False -> "Both"
+
 infix1 :: String -> String -> Int
 infix1 needle haystack = case isInfixOf needle haystack of
                             True -> 1


### PR DESCRIPTION
Corresponding base branch: https://github.com/BillHallahan/base-4.9.1.0/tree/smt-indexof
Mostly tests and str.indexof support
