### PR TITLE
Type families

### DIFF
--- a/base_setup.sh
+++ b/base_setup.sh
@@ -1,4 +1,4 @@
-base_commit=0661c03
+base_commit=c5a2701
 stubs_commit=db1e16c
 
 get_base() {

--- a/g2.cabal
+++ b/g2.cabal
@@ -91,6 +91,7 @@ library
                        , G2.Language.CreateFuncs
                        , G2.Language.Expr
                        , G2.Language.ExprEnv
+                       , G2.Language.Families
                        , G2.Language.Ids
                        , G2.Language.KnownValues
                        , G2.Language.Located

--- a/src/G2/Initialization/Types.hs
+++ b/src/G2/Initialization/Types.hs
@@ -22,6 +22,7 @@ data SimpleState = SimpleState { expr_env :: L.ExprEnv
                                , handles :: HM.HashMap Name L.Handle
                                , known_values :: L.KnownValues
                                , type_classes :: L.TypeClasses
+                               , families :: L.Families
                                , rewrite_rules :: ![L.RewriteRule]
                                , exports :: [Name] } deriving (Eq, Show, Read)
 
@@ -89,8 +90,9 @@ instance ASTContainer SimpleState Expr where
 
 instance ASTContainer SimpleState Type where
     containedASTs s =
-        containedASTs (expr_env s) ++ containedASTs (type_env s) ++ containedASTs  (rewrite_rules s)
+        containedASTs (expr_env s) ++ containedASTs (type_env s) ++ containedASTs (families s) ++ containedASTs  (rewrite_rules s)
     modifyContainedASTs f s = s { expr_env = modifyContainedASTs f (expr_env s)
                                 , type_env = modifyContainedASTs f (type_env s)
+                                , families = modifyContainedASTs f (families s)
                                 , handles = modifyContainedASTs f (handles s)
                                 , rewrite_rules = modifyContainedASTs f (rewrite_rules s) }

--- a/src/G2/Interface/Interface.hs
+++ b/src/G2/Interface/Interface.hs
@@ -174,6 +174,7 @@ initStateFromSimpleState s m_mod useAssert mkCurr argTys config =
         hs = IT.handles s'
         kv' = IT.known_values s'
         tc' = IT.type_classes s'
+        fams = IT.families s'
         CurrExprRes { ce_expr = ce
                     , fixed_in = f_i
                     , symbolic_type_ids = typ_is
@@ -193,6 +194,7 @@ initStateFromSimpleState s m_mod useAssert mkCurr argTys config =
     , true_assert = if useAssert || check_asserts config then False else True
     , assert_ids = Nothing
     , type_classes = tc'
+    , families = fams
     , exec_stack = Stack.empty
     , model = HM.empty
     , known_values = kv'
@@ -240,12 +242,14 @@ initSimpleState :: ExtractedG2
 initSimpleState (ExtractedG2 { exg2_binds = prog
                              , exg2_tycons = prog_typ
                              , exg2_classes = cls
+                             , exg2_axioms = axs
                              , exg2_exports = es
                              , exg2_rules = rs }) =
     let
         eenv = E.fromExprMap prog
         tenv = mkTypeEnv prog_typ
         tc = initTypeClasses TV.empty cls
+        fams = mkFamilies axs
         kv = initKnownValues eenv tenv tc
         ng = mkNameGen (prog, prog_typ, rs)
 
@@ -255,6 +259,7 @@ initSimpleState (ExtractedG2 { exg2_binds = prog
                            , IT.handles = HM.empty
                            , IT.known_values = kv
                            , IT.type_classes = tc
+                           , IT.families = fams
                            , IT.rewrite_rules = rs
                            , IT.exports = es }
     in

--- a/src/G2/Language.hs
+++ b/src/G2/Language.hs
@@ -5,6 +5,7 @@ module G2.Language
     , module G2.Language.AST
     , module G2.Language.CreateFuncs
     , module G2.Language.Expr
+    , module G2.Language.Families
     , module G2.Language.Ids
     , module G2.Language.Located
     , module G2.Language.MutVarEnv
@@ -20,6 +21,7 @@ import G2.Language.ArbValueGen
 import G2.Language.AST
 import G2.Language.CreateFuncs
 import G2.Language.Expr
+import G2.Language.Families
 import G2.Language.Ids
 import G2.Language.Located
 import G2.Language.MutVarEnv

--- a/src/G2/Language/AST.hs
+++ b/src/G2/Language/AST.hs
@@ -28,8 +28,9 @@ module G2.Language.AST
     ) where
 
 import qualified G2.Data.UFMap as UF
-import G2.Language.Syntax
 import G2.Language.AlgDataTy
+import G2.Language.Families
+import G2.Language.Syntax
 
 import Data.Hashable
 import qualified Data.HashMap.Lazy as HM
@@ -473,6 +474,23 @@ instance ASTContainer Int Type where
     containedASTs _ = []
     modifyContainedASTs _ t = t
 
+instance ASTContainer Family Expr where
+    containedASTs (Family ax) = containedASTs ax
+    modifyContainedASTs f (Family { axioms = ax }) = Family { axioms = modifyContainedASTs f ax }
+
+instance ASTContainer Family Type where
+    containedASTs (Family ax) = containedASTs ax
+    modifyContainedASTs f (Family { axioms = ax }) = Family { axioms = modifyContainedASTs f ax }
+
+instance ASTContainer Axiom Expr where
+    containedASTs (Axiom lhs rhs) = containedASTs lhs <> containedASTs rhs
+    modifyContainedASTs f (Axiom { lhs_types = lhs, rhs_type = rhs }) =
+        Axiom { lhs_types = modifyContainedASTs f lhs, rhs_type = modifyContainedASTs f rhs }
+
+instance ASTContainer Axiom Type where
+    containedASTs (Axiom lhs rhs) = containedASTs lhs <> containedASTs rhs
+    modifyContainedASTs f (Axiom { lhs_types = lhs, rhs_type = rhs }) =
+        Axiom { lhs_types = modifyContainedASTs f lhs, rhs_type = modifyContainedASTs f rhs }
 
 -- AlgDataTy
 instance ASTContainer AlgDataTy Expr where

--- a/src/G2/Language/Arbitrary.hs
+++ b/src/G2/Language/Arbitrary.hs
@@ -83,6 +83,7 @@ instance Arbitrary ArbSimpleState where
                                       , IT.name_gen = mkNameGen (tenv, e)
                                       , IT.known_values = fakeKnownValues
                                       , IT.type_classes = initTypeClasses TV.empty []
+                                      , IT.families = HM.empty
                                       , IT.rewrite_rules = []
                                       , IT.exports = []
                                       , IT.handles = HM.empty

--- a/src/G2/Language/Families.hs
+++ b/src/G2/Language/Families.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE DeriveGeneric, DeriveDataTypeable #-}
+
+module G2.Language.Families ( Families
+                            , Family (..)
+                            , Axiom (..)
+                            , mkFamilies ) where
+
+import G2.Language.Syntax
+
+import GHC.Generics (Generic)
+import Data.Data (Data, Typeable)
+import Data.Foldable
+import Data.Hashable
+import qualified Data.HashMap.Lazy as HM
+
+type Families = HM.HashMap Name Family
+
+newtype Family = Family { axioms :: [Axiom] }
+              deriving (Show, Eq, Read, Generic, Typeable, Data)
+
+instance Hashable Family
+
+-- An equality between a type function application and some type
+data Axiom = Axiom { lhs_types :: [Type] -- ^ Type arguments to match on
+                   , rhs_type :: Type -- ^ RHS of type equality 
+                   }
+                   deriving (Show, Eq, Read, Generic, Typeable, Data)
+
+instance Hashable Axiom
+
+mkFamilies :: [(Name, Axiom)] -> Families
+mkFamilies = foldl' addAxiom HM.empty
+    where
+        addAxiom fams (n, ax) =
+            HM.alter (Just . maybe (Family [ax]) (ins ax)) n fams
+        
+        ins ax (Family axs) = Family (ax:axs)

--- a/src/G2/Language/Naming.hs
+++ b/src/G2/Language/Naming.hs
@@ -51,6 +51,7 @@ module G2.Language.Naming
 
 import qualified G2.Data.UFMap as UF
 import G2.Language.AST
+import G2.Language.Families
 import G2.Language.KnownValues
 import G2.Language.Syntax
 import G2.Language.TypeEnv
@@ -533,6 +534,17 @@ instance Named FuncCall where
     renames hm (FuncCall {funcName = n, arguments = as, returns = r} ) =
         FuncCall {funcName = renames hm n, arguments = renames hm as, returns = renames hm r}
 
+instance Named Family where
+    names (Family { axioms = ax }) = names ax
+    rename old new (Family { axioms = ax }) = Family { axioms = rename old new ax }
+    renames hm (Family { axioms = ax }) = Family { axioms = renames hm ax }
+
+instance Named Axiom where
+    names (Axiom lhs_t rhs_t ) = names lhs_t <> names rhs_t
+    rename old new (Axiom { lhs_types = lhs_t, rhs_type = rhs_t }) =
+        Axiom { lhs_types = rename old new lhs_t, rhs_type = rename old new rhs_t }
+    renames hm (Axiom { lhs_types = lhs_t, rhs_type = rhs_t }) =
+        Axiom { lhs_types = renames hm lhs_t, rhs_type = renames hm rhs_t }
 
 instance Named AlgDataTy where
     names (DataTyCon ns dc _) = names ns <> names dc

--- a/src/G2/Language/Support.hs
+++ b/src/G2/Language/Support.hs
@@ -18,7 +18,7 @@ module G2.Language.Support
 
 import G2.Language.AST
 import qualified G2.Language.ExprEnv as E
-import qualified G2.Language.TyVarEnv as TV
+import G2.Language.Families
 import G2.Language.KnownValues
 import G2.Language.MutVarEnv
 import G2.Language.Naming
@@ -28,6 +28,7 @@ import G2.Language.Syntax
 import G2.Language.TypeClasses
 import G2.Language.TypeEnv
 import G2.Language.Typing
+import qualified G2.Language.TyVarEnv as TV
 import G2.Language.PathConds hiding (map, filter)
 import G2.Execution.RuleTypes
 
@@ -57,6 +58,7 @@ data State t = State { expr_env :: E.ExprEnv -- ^ Mapping of `Name`s to `Expr`s
                                            -- When running to violate assertions, an assertion violations flips this from False to True.
                      , assert_ids :: Maybe FuncCall
                      , type_classes :: TypeClasses
+                     , families :: Families
                      , exec_stack :: Stack Frame
                      , model :: Model
                      , known_values :: KnownValues
@@ -206,6 +208,7 @@ instance Named t => Named (State t) where
             <> names (mutvar_env s)
             <> names (assert_ids s)
             <> names (type_classes s)
+            <> names (families s)
             <> names (exec_stack s)
             <> names (model s)
             <> names (known_values s)
@@ -227,6 +230,7 @@ instance Named t => Named (State t) where
                , true_assert = true_assert s
                , assert_ids = rename old new (assert_ids s)
                , type_classes = rename old new (type_classes s)
+               , families = rename old new (families s)
                , exec_stack = rename old new (exec_stack s)
                , model = rename old new (model s)
                , known_values = rename old new (known_values s)
@@ -252,6 +256,7 @@ instance Named t => Named (State t) where
                , true_assert = true_assert s
                , assert_ids = renames hm (assert_ids s)
                , type_classes = renames hm (type_classes s)
+               , families = renames hm (families s)
                , exec_stack = renames hm (exec_stack s)
                , model = renames hm (model s)
                , known_values = renames hm (known_values s)
@@ -303,6 +308,7 @@ instance ASTContainer t Type => ASTContainer (State t) Type where
                       (containedASTs $ mutvar_env s) ++
                       ((containedASTs . assert_ids) s) ++
                       ((containedASTs . type_classes) s) ++
+                      ((containedASTs . families) s) ++
                       ((containedASTs . exec_stack) s) ++
                       (containedASTs $ track s) ++ 
                       (containedASTs $ sym_gens s) ++
@@ -318,6 +324,7 @@ instance ASTContainer t Type => ASTContainer (State t) Type where
                                 , mutvar_env = modifyContainedASTs f $ mutvar_env s
                                 , assert_ids = (modifyContainedASTs f . assert_ids) s
                                 , type_classes = (modifyContainedASTs f . type_classes) s
+                                , families = (modifyContainedASTs f . families) s
                                 , exec_stack = (modifyContainedASTs f . exec_stack) s
                                 , track = modifyContainedASTs f $ track s 
                                 , sym_gens = modifyContainedASTs f $ sym_gens s 

--- a/src/G2/Lib/Printers.hs
+++ b/src/G2/Lib/Printers.hs
@@ -540,8 +540,11 @@ mkTypeHaskellPG pg (TyCon n _) | nameOcc n == "List"
                                | ("Tuple", k_str) <- T.splitAt 5 (nameOcc n)
                                , nameModule n == Just "GHC.Tuple.Prim"
                                , Just k <- readMaybe (T.unpack k_str) = "(" <> T.pack (replicate (k - 1) ',') <> ")"
+                               | Just (c, _) <- T.uncons (nameOcc n)
+                               , not (isAlphaNum c) = "(" <> mkNameHaskell pg n <> ")"
                                | otherwise = mkNameHaskell pg n
-mkTypeHaskellPG pg (TyApp t1 t2) = "(" <> mkTypeHaskellPG pg t1 <> " " <> mkTypeHaskellPG pg t2 <> ")"
+mkTypeHaskellPG pg ty_app@(TyApp _ _)
+    | ts <- unTyApp ty_app= "(" <> T.intercalate " " (map (mkTypeHaskellPG pg) ts) <> ")"
 mkTypeHaskellPG pg (TyForAll i t) = "forall " <> mkIdHaskell pg i <> " . " <> mkTypeHaskellPG pg t
 mkTypeHaskellPG _ TyBottom = "Bottom"
 mkTypeHaskellPG _ TYPE = "Type"

--- a/src/G2/Translation/GHC.hs
+++ b/src/G2/Translation/GHC.hs
@@ -7,6 +7,7 @@ module G2.Translation.GHC ( module GHC
                           , module GHC.Core.Class
                           , module GHC.Core.Coercion
                           , module GHC.Core.DataCon
+                          , module GHC.Core.FamInstEnv
                           , module GHC.Core.InstEnv
                           , module GHC.Core.TyCo.Rep
                           , module GHC.Core.TyCon
@@ -64,6 +65,7 @@ import GHC.Core ( Alt (..)
 import GHC.Core.Class (classAllSelIds, className, classSCTheta, classTyVars)
 import GHC.Core.Coercion
 import GHC.Core.DataCon
+import GHC.Core.FamInstEnv hiding (pprFamInst)
 import GHC.Core.InstEnv
 import GHC.Core.TyCo.Rep
 import GHC.Core.TyCon

--- a/src/G2/Translation/GHC.hs
+++ b/src/G2/Translation/GHC.hs
@@ -6,6 +6,7 @@ module G2.Translation.GHC ( module GHC
                           , module GHC.Core
                           , module GHC.Core.Class
                           , module GHC.Core.Coercion
+                          , module GHC.Core.Coercion.Axiom
                           , module GHC.Core.DataCon
                           , module GHC.Core.FamInstEnv
                           , module GHC.Core.InstEnv
@@ -64,6 +65,7 @@ import GHC.Core ( Alt (..)
                 , bindersOf)
 import GHC.Core.Class (classAllSelIds, className, classSCTheta, classTyVars)
 import GHC.Core.Coercion
+import GHC.Core.Coercion.Axiom
 import GHC.Core.DataCon
 import GHC.Core.FamInstEnv hiding (pprFamInst)
 import GHC.Core.InstEnv

--- a/src/G2/Translation/GHC.hs
+++ b/src/G2/Translation/GHC.hs
@@ -113,10 +113,12 @@ import GHC.Driver.Ways
 
 module G2.Translation.GHC ( module Avail
                           , module Class
+                          , module CoAxiom
                           , module Coercion
                           , module CoreSyn
                           , module DataCon
                           , module DynFlags
+                          , module FamInstEnv
                           , module FastString
                           , module GHC
                           , module GHC.Paths
@@ -136,10 +138,12 @@ module G2.Translation.GHC ( module Avail
 
 import Avail
 import Class (classAllSelIds, className, classSCTheta, classTyVars)
+import CoAxiom
 import Coercion
 import CoreSyn
 import DataCon
 import DynFlags
+import FamInstEnv hiding (pprFamInst)
 import FastString
 import GHC hiding (AnnKeywordId (..), AnnExpr' (..))
 import GHC.Paths

--- a/src/G2/Translation/HaskellCheck.hs
+++ b/src/G2/Translation/HaskellCheck.hs
@@ -145,7 +145,6 @@ runCheck init_pg modN entry chAll chAny b er@(ExecRes {final_state = s, conc_arg
                                         ++ outStr ++ " :: " ++ outType ++ ")" ++ ")) :: IO (Either SomeException Bool)"
                     True -> mvStr ++ "Control.Exception.try (evaluate ( (" ++ pr_con ++ "(" ++ arsStr ++ " :: " ++ arsType ++ ")" ++
                                                     ") == " ++ pr_con ++ "(" ++ arsStr ++ "))) :: IO (Either SomeException Bool)"
-    liftIO $ putStrLn chck
     v' <- compileExpr chck
 
     let chArgs = ars ++ [out] 

--- a/src/G2/Translation/HaskellCheck.hs
+++ b/src/G2/Translation/HaskellCheck.hs
@@ -145,6 +145,7 @@ runCheck init_pg modN entry chAll chAny b er@(ExecRes {final_state = s, conc_arg
                                         ++ outStr ++ " :: " ++ outType ++ ")" ++ ")) :: IO (Either SomeException Bool)"
                     True -> mvStr ++ "Control.Exception.try (evaluate ( (" ++ pr_con ++ "(" ++ arsStr ++ " :: " ++ arsType ++ ")" ++
                                                     ") == " ++ pr_con ++ "(" ++ arsStr ++ "))) :: IO (Either SomeException Bool)"
+    liftIO $ putStrLn chck
     v' <- compileExpr chck
 
     let chArgs = ars ++ [out] 

--- a/src/G2/Translation/TransTypes.hs
+++ b/src/G2/Translation/TransTypes.hs
@@ -10,6 +10,7 @@ import qualified Data.Text as T
 
 import qualified G2.Language.Syntax as G2
 import qualified G2.Language.AlgDataTy as G2
+import qualified G2.Language.Families as G2
 
 type NameMap = HM.HashMap (T.Text, Maybe T.Text) G2.Name
 
@@ -38,6 +39,7 @@ data ModGutsClosure = ModGutsClosure
   , mgcc_tycons :: [TyCon]
   , mgcc_breaks :: Maybe ModBreaks
   , mgcc_cls_insts :: [ClsInst]
+  , mgcc_fam_insts :: [FamInst]
   , mgcc_type_env :: TypeEnv
   , mgcc_exports :: [ExportedName]
   , mgcc_deps :: [String]
@@ -47,6 +49,7 @@ data ModGutsClosure = ModGutsClosure
 
 data ModDetailsClosure = ModDetailsClosure
   { mdcc_cls_insts :: [ClsInst]
+  , mdcc_fam_insts :: [FamInst]
   , mdcc_type_env :: TypeEnv
   , mdcc_exports :: [ExportedName]
   , mdcc_deps :: [String]
@@ -69,6 +72,7 @@ emptyModGutsClosure =
     , mgcc_tycons = []
     , mgcc_breaks = Nothing
     , mgcc_cls_insts = []
+    , mgcc_fam_insts = []
     , mgcc_type_env = emptyTypeEnv
     , mgcc_exports = []
     , mgcc_deps = []
@@ -79,6 +83,7 @@ emptyModDetailsClosure :: ModDetailsClosure
 emptyModDetailsClosure =
   ModDetailsClosure
     { mdcc_cls_insts = []
+    , mdcc_fam_insts = []
     , mdcc_type_env = emptyTypeEnv
     , mdcc_exports = []
     , mdcc_deps = []
@@ -100,6 +105,7 @@ data ExtractedG2 = ExtractedG2
   , exg2_binds :: HM.HashMap G2.Name G2.Expr
   , exg2_tycons :: HM.HashMap G2.Name G2.AlgDataTy
   , exg2_classes :: [(G2.Name, G2.Id, [G2.Id], [(G2.Type, G2.Id)])]
+  , exg2_axioms :: [(G2.Name, G2.Axiom)]
   , exg2_exports :: [ExportedName]
   , exg2_deps :: [T.Text]
   , exg2_rules :: ![G2.RewriteRule]
@@ -112,6 +118,7 @@ emptyExtractedG2 =
     , exg2_binds = HM.empty
     , exg2_tycons = HM.empty
     , exg2_classes = []
+    , exg2_axioms = []
     , exg2_exports = []
     , exg2_deps = []
     , exg2_rules = [] }

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -687,6 +687,18 @@ extensionTests = testGroup "Extensions"
                                                                         , ("vecLength", 1000, [AtLeast 10])
                                                                         , ("vecZip", 1000, [AtLeast 10])
                                                                         ]
+
+    , checkInputOutputsInstType "tests/TestFiles/Extensions/TypeFamilies1.hs" [ ("f", 400, [Exactly 2])
+                                                                              , ("f2", 400, [AtLeast 1])
+                                                                              , ("f3", 400, [Exactly 2])
+                                                                              , ("g", 400, [Exactly 2])
+                                                                              , ("h", 400, [Exactly 2])
+                                                                              , ("age1", 400, [Exactly 1])
+                                                                              , ("age2", 400, [Exactly 1])
+                                                                              , ("app", 250, [AtLeast 5])
+                                                                              ]
+                                                            
+
     ]
 
 baseTests ::  TestTree

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -697,8 +697,10 @@ extensionTests = testGroup "Extensions"
                                                                               , ("age2", 400, [Exactly 1])
                                                                               , ("app", 250, [AtLeast 5])
                                                                               ]
-                                                            
-
+    , checkInputOutputsInstType "tests/TestFiles/Extensions/DataFamilies1.hs" [ ("f", 400, [Exactly 2])
+                                                                              , ("app3Char", 400, [AtLeast 1])
+                                                                              , ("app3Unit", 400, [AtLeast 1])
+                                                                              ]
     ]
 
 baseTests ::  TestTree

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -696,20 +696,20 @@ extensionTests = testGroup "Extensions"
                                                                         ]
 
     , checkInputOutputsInstType "tests/TestFiles/Extensions/TypeFamilies1.hs" [ ("f", 400, [Exactly 2])
-                                                                              , ("f2", 400, [AtLeast 1])
+                                                                              -- , ("f2", 400, [AtLeast 1])
                                                                               , ("f3", 400, [Exactly 3])
                                                                               , ("g", 400, [Exactly 2])
                                                                               , ("h", 400, [Exactly 2])
                                                                               , ("age1", 400, [Exactly 1])
-                                                                              , ("age2", 400, [Exactly 1])
-                                                                              , ("app", 250, [AtLeast 5])
-                                                                              , ("vecIntersperse", 400, [AtLeast 5])
+                                                                              -- , ("age2", 400, [Exactly 1])
+                                                                              -- , ("app", 250, [AtLeast 5])
+                                                                              -- , ("vecIntersperse", 400, [AtLeast 5])
                                                                               , ("vecTake", 400, [AtLeast 5])
                                                                               ]
-    , checkInputOutputsInstType "tests/TestFiles/Extensions/DataFamilies1.hs" [ ("f", 400, [Exactly 2])
-                                                                              , ("app3Char", 400, [AtLeast 1])
-                                                                              , ("app3Unit", 400, [AtLeast 1])
-                                                                              ]
+    -- , checkInputOutputsInstType "tests/TestFiles/Extensions/DataFamilies1.hs" [ ("f", 400, [Exactly 2])
+    --                                                                           , ("app3Char", 400, [AtLeast 1])
+    --                                                                           , ("app3Unit", 400, [AtLeast 1])
+    --                                                                           ]
     ]
 
 baseTests ::  TestTree

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -696,6 +696,8 @@ extensionTests = testGroup "Extensions"
                                                                               , ("age1", 400, [Exactly 1])
                                                                               , ("age2", 400, [Exactly 1])
                                                                               , ("app", 250, [AtLeast 5])
+                                                                              , ("vecIntersperse", 400, [AtLeast 5])
+                                                                              , ("vecTake", 400, [AtLeast 5])
                                                                               ]
     , checkInputOutputsInstType "tests/TestFiles/Extensions/DataFamilies1.hs" [ ("f", 400, [Exactly 2])
                                                                               , ("app3Char", 400, [AtLeast 1])

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -697,7 +697,7 @@ extensionTests = testGroup "Extensions"
 
     , checkInputOutputsInstType "tests/TestFiles/Extensions/TypeFamilies1.hs" [ ("f", 400, [Exactly 2])
                                                                               , ("f2", 400, [AtLeast 1])
-                                                                              , ("f3", 400, [Exactly 2])
+                                                                              , ("f3", 400, [Exactly 3])
                                                                               , ("g", 400, [Exactly 2])
                                                                               , ("h", 400, [Exactly 2])
                                                                               , ("age1", 400, [Exactly 1])

--- a/tests/TestFiles/Extensions/DataFamilies1.hs
+++ b/tests/TestFiles/Extensions/DataFamilies1.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE TypeFamilies #-}
+
+module DataFamilies1 where
+
+data family A a
+
+data instance A Int = AI Int
+data instance A Float = AF Float
+
+f :: A Int -> Int
+f (AI x) = x
+
+-- Adapted from https://wiki.haskell.org/index.php?title=GHC/Type_families
+
+-- Declare a list-like data family
+class AdaptList a where
+    data XList a
+    app :: XList a -> XList a -> XList a
+
+-- Declare a list-like instance for Char
+instance AdaptList Char where
+    data XList Char = XCons Char (XList Char) | XNil
+    app XNil ys = ys
+    app (XCons c xs) ys = XCons c (app xs ys)
+
+-- Declare a number-like instance for ()
+instance AdaptList () where
+    data XList () = XListUnit !Int
+    app (XListUnit n1) (XListUnit n2) = XListUnit (n1 + n2)
+
+app3 :: AdaptList a => XList a -> XList a -> XList a -> XList a
+app3 xs ys zs = app xs (app ys zs)
+
+app3Char :: XList Char -> XList Char -> XList Char -> XList Char
+app3Char = app3
+
+app3Unit :: XList () -> XList () -> XList () -> XList ()
+app3Unit = app3

--- a/tests/TestFiles/Extensions/TypeFamilies1.hs
+++ b/tests/TestFiles/Extensions/TypeFamilies1.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE TypeFamilies #-}
+
+module TypeFamily where
+
+type family F a where
+    F Int = Bool
+    F Bool = Int
+
+data C a where
+    I :: C Int
+    B :: C Bool 
+
+f :: C a -> F a
+f I = True
+f B = 0

--- a/tests/TestFiles/Extensions/TypeFamilies1.hs
+++ b/tests/TestFiles/Extensions/TypeFamilies1.hs
@@ -1,8 +1,9 @@
-{-# LANGUAGE DataKinds, TypeFamilies #-}
+{-# LANGUAGE AllowAmbiguousTypes, DataKinds, TypeFamilies, UndecidableInstances #-}
 
 module TypeFamilies1 where
 
 import Data.Kind
+import Data.Type.Equality
 
 type family F a where
     F Int = Bool
@@ -72,6 +73,10 @@ infixr 5 :>
 
 deriving instance Eq a => Eq (Vec n a)
 
+vecLength :: Vec n a -> SNat n
+vecLength Nil = SZero
+vecLength (_ :> xs) = SSucc (vecLength xs)
+
 type (+) :: Nat -> Nat -> Nat
 type family a + b where
     Zero + b = b
@@ -86,5 +91,36 @@ zipDouble Nil ys v = vecZip ys v
 zipDouble (x :> xs) ys (z :> zs) = (x, z) :> (zipDouble xs ys zs)
 
 vecZip :: Vec n a -> Vec n b -> Vec n (a, b)
-vecZip Nil _ =  Nil 
+vecZip Nil _ =  Nil
 vecZip (x :> xs) (y :> ys) = (x, y) :> vecZip xs ys
+
+type InterLength :: Nat -> Nat
+type family InterLength n where
+    InterLength Zero = Zero
+    InterLength (Succ Zero) = Succ Zero
+    InterLength (Succ n) = Succ (n + n)
+
+vecIntersperse :: a -> Vec n a -> Vec (InterLength n) a
+vecIntersperse _ Nil = Nil
+vecIntersperse _ (x :> Nil) = x :> Nil
+vecIntersperse sep ((x :> (xs@(_ :> _))) :: Vec xs_len a) = x :> vecPrependToAll sep xs
+
+addSuccM :: forall n m . SNat m -> m + Succ n :~: Succ (m + n)
+addSuccM SZero = Refl
+addSuccM (SSucc m) = case addSuccM @n m of Refl -> Refl
+
+vecPrependToAll :: a -> Vec n a -> Vec (n + n) a
+vecPrependToAll _ Nil = Nil
+vecPrependToAll sep (x :> (xs :: Vec xs_len a)) =
+    case addSuccM @xs_len (vecLength xs) of Refl -> sep :> x :> vecPrependToAll sep xs
+
+type Min :: Nat -> Nat -> Nat
+type family Min a b where
+  Min Zero _ = Zero
+  Min (Succ _) Zero = Zero
+  Min (Succ n) (Succ m) = Succ (Min n m)
+
+vecTake :: SNat n -> Vec m a -> Vec (Min n m) a
+vecTake SZero _ = Nil
+vecTake (SSucc _) Nil       = Nil
+vecTake (SSucc n') (x :> xs) = x :> vecTake n' xs

--- a/tests/TestFiles/Extensions/TypeFamilies1.hs
+++ b/tests/TestFiles/Extensions/TypeFamilies1.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE AllowAmbiguousTypes, DataKinds, TypeFamilies, UndecidableInstances #-}
+{-# LANGUAGE AllowAmbiguousTypes, DataKinds, GADTs, RankNTypes, ScopedTypeVariables,
+             StandaloneDeriving, StandaloneKindSignatures, TypeApplications,
+             TypeFamilies, TypeOperators, UndecidableInstances #-}
 
 module TypeFamilies1 where
 
@@ -22,7 +24,7 @@ f2 I x = x
 f2 B x = x
 
 f3 :: C a -> F a -> F a
-f3 I x = not x
+f3 I x = case x of True -> False; False -> True
 f3 B x = x + 1
 
 type family G a

--- a/tests/TestFiles/Extensions/TypeFamilies1.hs
+++ b/tests/TestFiles/Extensions/TypeFamilies1.hs
@@ -1,6 +1,8 @@
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DataKinds, TypeFamilies #-}
 
 module TypeFamily where
+
+import Data.Kind
 
 type family F a where
     F Int = Bool
@@ -13,3 +15,64 @@ data C a where
 f :: C a -> F a
 f I = True
 f B = 0
+
+f2 :: C a -> F a -> F a
+f2 I x = not x
+f2 B x = x + 1
+
+type family G a
+    
+g :: C a -> G a
+g I = True
+g B = 0
+
+type instance G Int = Bool
+type instance G Bool = Int
+
+type family H a b where
+    H Int (k, v) = k
+    H Bool (k, v) = v
+
+h :: C a -> (k, v) -> H a (k, v)
+h I (k, _) = k
+h B (_, v) = v
+
+newtype Age = Age Int deriving (Eq, Show)
+
+type family N a where
+    N Int = Age
+
+age1 :: Int -> N Int
+age1 x = Age x
+
+age2 :: a ~ Int => a -> N a
+age2 x = Age x
+
+-------------------------------------------------------------------------------
+-- Vecs
+
+data Nat = Zero | Succ Nat
+
+type SNat :: Nat -> Type
+data SNat n where
+    SZero :: SNat Zero
+    SSucc :: SNat n -> SNat (Succ n)
+
+deriving instance Eq (SNat n)
+
+type Vec :: Nat -> Type -> Type
+data Vec n a where
+    Nil  :: Vec Zero a
+    (:>) :: a -> Vec n a -> Vec (Succ n) a
+infixr 5 :>
+
+deriving instance Eq a => Eq (Vec n a)
+
+type (+) :: Nat -> Nat -> Nat
+type family a + b where
+    Zero + b = b
+    Succ a + b = Succ (a + b)
+
+app :: Vec n a -> Vec m a -> Vec (n + m) a
+Nil `app` v = v
+(x :> xs) `app` v = x :> (xs `app` v)

--- a/tests/TestFiles/Extensions/TypeFamilies1.hs
+++ b/tests/TestFiles/Extensions/TypeFamilies1.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DataKinds, TypeFamilies #-}
 
-module TypeFamily where
+module TypeFamilies1 where
 
 import Data.Kind
 
@@ -17,8 +17,12 @@ f I = True
 f B = 0
 
 f2 :: C a -> F a -> F a
-f2 I x = not x
-f2 B x = x + 1
+f2 I x = x
+f2 B x = x
+
+f3 :: C a -> F a -> F a
+f3 I x = not x
+f3 B x = x + 1
 
 type family G a
     
@@ -74,5 +78,13 @@ type family a + b where
     Succ a + b = Succ (a + b)
 
 app :: Vec n a -> Vec m a -> Vec (n + m) a
-Nil `app` v = v
-(x :> xs) `app` v = x :> (xs `app` v)
+Nil `app` ys = ys
+(x :> xs) `app` ys = x :> (xs `app` ys)
+
+zipDouble :: Vec m a -> Vec n a -> Vec (m + n) b -> Vec (m + n) (a, b)
+zipDouble Nil ys v = vecZip ys v
+zipDouble (x :> xs) ys (z :> zs) = (x, z) :> (zipDouble xs ys zs)
+
+vecZip :: Vec n a -> Vec n b -> Vec n (a, b)
+vecZip Nil _ =  Nil 
+vecZip (x :> xs) (y :> ys) = (x, y) :> vecZip xs ys


### PR DESCRIPTION
Get some basic functionality in so that (1) G2 doesn't crash when run on code that uses type/data families and (2) G2 loads in equalities created by type/data families.  With this pull request, we can symbolic execute code that include families, but type functions are not reduced. So give input:
```
type family F a where
    F Int = Bool
    F Bool = Int

data C a where
    I :: C Int
    B :: C Bool 

f :: C a -> F a
f I = True
f B = 0
```
we get as output from G2:
```
f I = ((coerce (True :: Bool)) :: (F Int))
f B = ((coerce (0 :: Int)) :: (F Bool))
```
which could be neater if we reduced `F Int -> Bool`/`F Bool -> Int` and could then remove the coercions.

We will need to do this future work to reduce type functions- currently, things mostly work, but arbitrary value generation fails when passed a non-reduced type function application, and data families can introduce type functions that are not defined in the code and thus reduce validate.  There is also at least one case (app in TypeFamilies1.hs) where a type variable is not instantiated properly (?)- I believe this is not a new bug with the handling of coercions- but an existing bug that we need to address- because  nothing about type variable instantiation has been changed in this pull request. I've introduced commented out test cases that I hope/plan to uncomment in future pull requests addressing these problems. 

Corresponding base changes, which will also need to be reviewed/merged alongside this pull request:
https://github.com/BillHallahan/base-4.9.1.0/pull/18
