### PR TITLE
`any` and `filter` implemented with literal tables

### DIFF
--- a/.github/workflows/haskell.yaml
+++ b/.github/workflows/haskell.yaml
@@ -47,7 +47,7 @@ jobs:
       id: z3
       uses: cda-tum/setup-z3@v1
       with:
-        version: 4.15.4
+        version: 4.16.0
 
     - name: Install CVC5
       run: sudo apt-get install cvc5

--- a/base_setup.sh
+++ b/base_setup.sh
@@ -1,4 +1,4 @@
-base_commit=701cc5b
+base_commit=1b62055
 stubs_commit=4ff1c36
 
 get_base() {

--- a/base_setup.sh
+++ b/base_setup.sh
@@ -1,4 +1,4 @@
-base_commit=1b62055
+base_commit=497c902
 stubs_commit=4ff1c36
 
 get_base() {

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -363,7 +363,7 @@ testFileTests = testGroup "TestFiles"
                                                               , ("stringSub1", 7000, [AtLeast 40])
                                                               , ("stringSub2", 7000, [AtLeast 35])
                                                               , ("stringSub3", 7000, [AtLeast 16])
-                                                              , ("nStringSub3", 2000, [AtLeast 12])
+                                                              , ("nStringSub3", 2000, [AtLeast 13])
                                                               , ("stringSub4", 7000, [AtLeast 7])
                                                               , ("nStringSub4", 2000, [AtLeast 5])
                                                               , ("strLen", 1000, [AtLeast 5])
@@ -885,7 +885,7 @@ baseTests = testGroup "Base"
                                                        , ("minTest", 1000, [AtLeast 2])
                                                        , ("initsTest", 4000, [AtLeast 6])
                                                        , ("foldrTest2", 1000, [AtLeast 1])
-                                                       , ("unionTest", 1000, [AtLeast 9]) ]
+                                                       , ("unionTest", 1000, [AtLeast 8]) ]
 
     , checkInputOutputs "tests/BaseTests/Tuples.hs" [ ("addTupleElems", 1000, [AtLeast 2])
                                                     , ("applicativeTuple", 1000, [Exactly 1])

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -885,7 +885,7 @@ baseTests = testGroup "Base"
                                                        , ("minTest", 1000, [AtLeast 2])
                                                        , ("initsTest", 4000, [AtLeast 6])
                                                        , ("foldrTest2", 1000, [AtLeast 1])
-                                                       , ("unionTest", 1000, [AtLeast 8]) ]
+                                                       , ("unionTest", 1000, [AtLeast 7]) ]
 
     , checkInputOutputs "tests/BaseTests/Tuples.hs" [ ("addTupleElems", 1000, [AtLeast 2])
                                                     , ("applicativeTuple", 1000, [Exactly 1])

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -422,6 +422,7 @@ testFileTests = testGroup "TestFiles"
                                                               , ("all2", 500, [AtLeast 5])
                                                               , ("all3", 500, [AtLeast 5])
                                                               , ("all4", 500, [AtLeast 5])
+                                                              , ("any1", 500, [AtLeast 5])
                                                               ]
 
     , checkInputOutputsSMTStrings "tests/TestFiles/Strings/Strings1.hs"
@@ -551,7 +552,9 @@ testFileTests = testGroup "TestFiles"
                                            [ ("all1", 5000, [Exactly 2])
                                            , ("all2", 5000, [Exactly 2])
                                            , ("all3", 5000, [Exactly 3])
-                                           , ("all4", 5000, [Exactly 3]) ]
+                                           , ("all4", 5000, [Exactly 3])
+                                           , ("any1", 5000, [Exactly 3])
+                                           ]
 
     , checkInputOutputsSMTLists "tests/TestFiles/Seq/Seq1.hs" [ ("toEnum1", 2000, [Exactly 1])
                                                               , ("conInt", 1000, [Exactly 1]) 

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -363,7 +363,7 @@ testFileTests = testGroup "TestFiles"
                                                               , ("stringSub1", 7000, [AtLeast 40])
                                                               , ("stringSub2", 7000, [AtLeast 35])
                                                               , ("stringSub3", 7000, [AtLeast 16])
-                                                              , ("nStringSub3", 2000, [AtLeast 15])
+                                                              , ("nStringSub3", 2000, [AtLeast 12])
                                                               , ("stringSub4", 7000, [AtLeast 7])
                                                               , ("nStringSub4", 2000, [AtLeast 5])
                                                               , ("strLen", 1000, [AtLeast 5])

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -555,7 +555,7 @@ testFileTests = testGroup "TestFiles"
                                            , ("all3", 5000, [Exactly 3])
                                            , ("all4", 5000, [Exactly 3])
                                            , ("any1", 5000, [Exactly 3])
-                                           , ("filter1", 10000, [Exactly 5])
+                                           , ("filter1", 10000, [Exactly 4])
                                            ]
 
     , checkInputOutputsSMTLists "tests/TestFiles/Seq/Seq1.hs" [ ("toEnum1", 2000, [Exactly 1])

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -423,6 +423,7 @@ testFileTests = testGroup "TestFiles"
                                                               , ("all3", 500, [AtLeast 5])
                                                               , ("all4", 500, [AtLeast 5])
                                                               , ("any1", 500, [AtLeast 5])
+                                                              , ("filter1", 500, [AtLeast 5])
                                                               ]
 
     , checkInputOutputsSMTStrings "tests/TestFiles/Strings/Strings1.hs"
@@ -554,6 +555,7 @@ testFileTests = testGroup "TestFiles"
                                            , ("all3", 5000, [Exactly 3])
                                            , ("all4", 5000, [Exactly 3])
                                            , ("any1", 5000, [Exactly 3])
+                                           , ("filter1", 10000, [Exactly 5])
                                            ]
 
     , checkInputOutputsSMTLists "tests/TestFiles/Seq/Seq1.hs" [ ("toEnum1", 2000, [Exactly 1])

--- a/tests/TestFiles/Strings/Strings1.hs
+++ b/tests/TestFiles/Strings/Strings1.hs
@@ -638,8 +638,7 @@ any1 s = case L.any (== '&') s && length s > 4 of
 filter1 :: String -> Int
 filter1 s = case filter (/= '$') s of
                 "x" -> 1
-                "xyz" -> 2
-                _ -> 3
+                _ -> 2
 
 -- Note: z3 currently returns sat on some unsat SMT formulas
 -- this function outputs.

--- a/tests/TestFiles/Strings/Strings1.hs
+++ b/tests/TestFiles/Strings/Strings1.hs
@@ -630,22 +630,25 @@ all4 s = case L.all (\c -> c >= 'a' && c <= 'z') s && length s == 1 of
             True -> "Yes"
             False -> "No"
 
--- dropWhile1 :: String -> Int
--- dropWhile1 s = case dropWhile (\x -> x == 'c') s of
---                    "ok" -> 1
---                    _ -> 2
-
 any1 :: String -> Int
 any1 s = case L.any (== '&') s && length s > 4 of
             True -> 1
             False -> 2
 
 filter1 :: String -> Int
-filter1 s = if length s < 4 then 1
-            else case filter (== '$') s of
-                    "x" -> 2
-                    "xyz" -> 3
-                    _ -> 4
+filter1 s = case filter (/= '$') s of
+                "x" -> 1
+                "xyz" -> 2
+                _ -> 3
+
+-- Note: z3 currently returns sat on some unsat SMT formulas
+-- this function outputs.
+-- filter2 :: String -> Int
+-- filter2 s = if length s < 4 then 1
+--             else case filter (== '$') s of
+--                     "x" -> 2
+--                     "xyz" -> 3
+--                     _ -> 4
 
 testQualImp :: String -> M.Maybe Char
 testQualImp s = case "12345" `isInfixOf` s of

--- a/tests/TestFiles/Strings/Strings1.hs
+++ b/tests/TestFiles/Strings/Strings1.hs
@@ -630,6 +630,23 @@ all4 s = case L.all (\c -> c >= 'a' && c <= 'z') s && length s == 1 of
             True -> "Yes"
             False -> "No"
 
+-- dropWhile1 :: String -> Int
+-- dropWhile1 s = case dropWhile (\x -> x == 'c') s of
+--                    "ok" -> 1
+--                    _ -> 2
+
+any1 :: String -> Int
+any1 s = case L.any (== '&') s && length s > 4 of
+            True -> 1
+            False -> 2
+
+filter1 :: String -> Int
+filter1 s = if length s < 4 then 1
+            else case filter (== '$') s of
+                    "x" -> 2
+                    "xyz" -> 3
+                    _ -> 4
+
 testQualImp :: String -> M.Maybe Char
 testQualImp s = case "12345" `isInfixOf` s of
                     True -> M.Nothing


### PR DESCRIPTION
- There are still z3 bugs that this can hit (but the stuff in here should be correct), I left one commented out test case
- Base PR: https://github.com/BillHallahan/base-4.9.1.0/pull/47
- A couple test cases are flaky as a result of upgrading z3 to 4.16.0, probably performance regressions?