### PR TITLE
Continue validation after errors. More descriptive checkmarks.

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -47,10 +47,12 @@ runWithArgs as = do
 
   let (unspecified_output, spec_output) = L.partition (\ExecRes { final_state = s } -> getExpr s == Prim UnspecifiedOutput TyBottom) in_out
   
-  let notValidated = filter (\ExecRes{validated = val} -> case val of
-                                                                    Just m -> m == False
-                                                                    Nothing -> False ) in_out
-  let timeouts = filter (\ExecRes{validated = val} -> isNothing val) in_out
+  let notValidated = filter (\ExecRes{validate_result = val_res} -> case val_res of
+                                                                    Invalid -> True
+                                                                    ValidationSrcError _ -> True
+                                                                    ValidationRTError -> True
+                                                                    _ -> False ) in_out
+  let timeouts = filter (\ExecRes{validate_result = val_res} -> case val_res of ValidationTimeout -> True; _ -> False) in_out
 
   when (validate config') $ do
     if null notValidated then putStrLn "Validated" else putStrLn "There was an error during validation."
@@ -63,7 +65,12 @@ runWithArgs as = do
         putStrLn $ "Func arg states: " ++ show (length unspecified_output)
 
   when (measure_coverage config') $ do
+<<<<<<< HEAD
     runHPC src (measure_coverage_with config') (T.unpack $ fromJust mb_modname) entry (filter (\ExecRes{validated = val} -> fromMaybe False val) in_out)
+=======
+    runHPC src (measure_coverage_with config') (T.unpack $ fromJust mb_modname) entry 
+        (filter (\ExecRes{validate_result = val_res} -> case val_res of Valid -> True; _ -> False) in_out)
+>>>>>>> 731b22e5a (NO crash on GHC error. Report error and continue attempting to validate outputs. Also changes to allow compilation elsewhere.)
     case in_out of
         _:_ -> do
           let reachable = reachesHPC all_mods (expr_env init_state) (Var entry_f)

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -65,12 +65,8 @@ runWithArgs as = do
         putStrLn $ "Func arg states: " ++ show (length unspecified_output)
 
   when (measure_coverage config') $ do
-<<<<<<< HEAD
-    runHPC src (measure_coverage_with config') (T.unpack $ fromJust mb_modname) entry (filter (\ExecRes{validated = val} -> fromMaybe False val) in_out)
-=======
     runHPC src (measure_coverage_with config') (T.unpack $ fromJust mb_modname) entry 
         (filter (\ExecRes{validate_result = val_res} -> case val_res of Valid -> True; _ -> False) in_out)
->>>>>>> 731b22e5a (NO crash on GHC error. Report error and continue attempting to validate outputs. Also changes to allow compilation elsewhere.)
     case in_out of
         _:_ -> do
           let reachable = reachesHPC all_mods (expr_env init_state) (Var entry_f)

--- a/src/G2/Interface/ExecRes.hs
+++ b/src/G2/Interface/ExecRes.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleContexts, MultiParamTypeClasses, OverloadedStrings #-}
 {-# LANGUAGE InstanceSigs #-}
 
-module G2.Interface.ExecRes ( ExecRes (..), StartFunc, ValidateRes(..), printInputOutput, transValidateRes ) where
+module G2.Interface.ExecRes ( ExecRes (..), StartFunc, ValidateRes(..), printInputOutput) where
 
 import G2.Language
 import G2.Lib.Printers
@@ -74,10 +74,6 @@ printHandle :: PrettyGuide -> State t -> Name -> Expr -> Maybe T.Text
 printHandle _ s _ e | (Data (DataCon { dc_name = n }):_) <- unApp e
                     , n == dcEmpty (known_values s) = Nothing
 printHandle pg s n h = Just (" --- " <> printName pg n <> " --- \n\t" <> printHaskellPG pg s h)
-
-transValidateRes :: ValidateRes -> Bool
-transValidateRes Valid = True
-transValidateRes _ = False
 
 instance Named t => Named (ExecRes t) where
     names :: Named t => ExecRes t -> S.Seq Name

--- a/src/G2/Interface/ExecRes.hs
+++ b/src/G2/Interface/ExecRes.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleContexts, MultiParamTypeClasses, OverloadedStrings #-}
 {-# LANGUAGE InstanceSigs #-}
 
-module G2.Interface.ExecRes ( ExecRes (..), StartFunc, ValidateRes(..), printInputOutput) where
+module G2.Interface.ExecRes ( ExecRes (..), StartFunc, ValidateRes(..)) where
 
 import G2.Language
 import G2.Lib.Printers

--- a/src/G2/Interface/ExecRes.hs
+++ b/src/G2/Interface/ExecRes.hs
@@ -9,7 +9,9 @@ import G2.Lib.Printers
 import Data.Maybe
 import qualified Data.Sequence as S
 import qualified Data.Text as T
-import GHC.Types.SourceError
+
+import G2.Translation.GHC (SourceError)
+
 import G2.Language.KnownValues (KnownValues(dcEmpty))
 
 type StartFunc = T.Text

--- a/src/G2/Interface/ExecRes.hs
+++ b/src/G2/Interface/ExecRes.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleContexts, MultiParamTypeClasses, OverloadedStrings #-}
 {-# LANGUAGE InstanceSigs #-}
 
-module G2.Interface.ExecRes ( ExecRes (..), StartFunc, printInputOutput ) where
+module G2.Interface.ExecRes ( ExecRes (..), StartFunc, ValidateRes(..), printInputOutput, transValidateRes ) where
 
 import G2.Language
 import G2.Lib.Printers
@@ -9,6 +9,7 @@ import G2.Lib.Printers
 import Data.Maybe
 import qualified Data.Sequence as S
 import qualified Data.Text as T
+import GHC.Types.SourceError
 import G2.Language.KnownValues (KnownValues(dcEmpty))
 
 type StartFunc = T.Text
@@ -21,8 +22,10 @@ data ExecRes t = ExecRes { final_state :: State t -- ^ The final state.
                          , conc_mutvars :: [(Name, MVOrigin, Expr)]
                          , conc_handles :: [(Name, Expr)]
                          , violated :: Maybe FuncCall -- ^ A violated assertion
-                         , validated :: Maybe Bool
-                         } deriving (Show, Read)
+                         , validate_result :: ValidateRes
+                         } deriving (Show)
+
+data ValidateRes = Valid | Invalid | ValidationSrcError SourceError | ValidationRTError | ValidationTimeout deriving (Show)
 
 printInputOutput :: PrettyGuide
                  -> Id -- ^ Input function
@@ -70,6 +73,10 @@ printHandle _ s _ e | (Data (DataCon { dc_name = n }):_) <- unApp e
                     , n == dcEmpty (known_values s) = Nothing
 printHandle pg s n h = Just (" --- " <> printName pg n <> " --- \n\t" <> printHaskellPG pg s h)
 
+transValidateRes :: ValidateRes -> Bool
+transValidateRes Valid = True
+transValidateRes _ = False
+
 instance Named t => Named (ExecRes t) where
     names :: Named t => ExecRes t -> S.Seq Name
     names (ExecRes { final_state = s
@@ -88,7 +95,7 @@ instance Named t => Named (ExecRes t) where
                             , conc_mutvars = mv
                             , conc_handles = h
                             , violated = fc
-                            , validated = v }) =
+                            , validate_result = v }) =
       ExecRes { final_state = rename old new s
               , conc_args = rename old new es
               , conc_out = rename old new r
@@ -96,7 +103,7 @@ instance Named t => Named (ExecRes t) where
               , conc_mutvars = rename old new mv
               , conc_handles = rename old new h
               , violated = rename old new fc
-              , validated = v}
+              , validate_result = v}
 
     renames hm (ExecRes { final_state = s
                         , conc_args = es
@@ -105,7 +112,7 @@ instance Named t => Named (ExecRes t) where
                         , conc_mutvars = mv
                         , conc_handles = h
                         , violated = fc
-                        , validated =  v}) =
+                        , validate_result =  v}) =
       ExecRes { final_state = renames hm s
               , conc_args = renames hm es
               , conc_out = renames hm r
@@ -113,7 +120,7 @@ instance Named t => Named (ExecRes t) where
               , conc_mutvars = renames hm mv
               , conc_handles = renames hm h
               , violated = renames hm fc
-              , validated = v }
+              , validate_result = v }
 
 instance ASTContainer t Expr => ASTContainer (ExecRes t) Expr where
     containedASTs (ExecRes { final_state = s
@@ -131,7 +138,7 @@ instance ASTContainer t Expr => ASTContainer (ExecRes t) Expr where
                                    , conc_mutvars = mv
                                    , conc_handles = h
                                    , violated = fc
-                                   , validated = v }) =
+                                   , validate_result = v }) =
         ExecRes { final_state = modifyContainedASTs f s
                 , conc_args = modifyContainedASTs f es
                 , conc_out = modifyContainedASTs f r
@@ -139,7 +146,7 @@ instance ASTContainer t Expr => ASTContainer (ExecRes t) Expr where
                 , conc_mutvars = modifyContainedASTs f mv
                 , conc_handles = h
                 , violated = modifyContainedASTs f fc
-                , validated = v}
+                , validate_result = v}
 
 instance ASTContainer t Type => ASTContainer (ExecRes t) Type where
     containedASTs (ExecRes { final_state = s
@@ -157,7 +164,7 @@ instance ASTContainer t Type => ASTContainer (ExecRes t) Type where
                                    , conc_mutvars = mv
                                    , conc_handles = h
                                    , violated = fc
-                                   , validated = v }) =
+                                   , validate_result = v }) =
         ExecRes { final_state = modifyContainedASTs f s
                 , conc_args = modifyContainedASTs f es
                 , conc_out = modifyContainedASTs f r
@@ -165,4 +172,4 @@ instance ASTContainer t Type => ASTContainer (ExecRes t) Type where
                 , conc_mutvars = modifyContainedASTs f mv
                 , conc_handles = h
                 , violated = modifyContainedASTs f fc
-                , validated = v }
+                , validate_result = v }

--- a/src/G2/Interface/ExecRes.hs
+++ b/src/G2/Interface/ExecRes.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleContexts, MultiParamTypeClasses, OverloadedStrings #-}
 {-# LANGUAGE InstanceSigs #-}
 
-module G2.Interface.ExecRes ( ExecRes (..), StartFunc, ValidateRes(..)) where
+module G2.Interface.ExecRes ( ExecRes (..), StartFunc, ValidateRes(..), printInputOutput) where
 
 import G2.Language
 import G2.Lib.Printers

--- a/src/G2/Interface/Interface.hs
+++ b/src/G2/Interface/Interface.hs
@@ -852,16 +852,16 @@ runG2SolvingValidate modN entry entry_id config solver simplifier s bindings = d
         SAT (m, ng) | validate config -> do
                 let m' = if print_encode_float config then toEnclodeFloat m else m
 
-                (res', isVal) <- runValidate (validate_with config) modN entry solver simplifier bindings m' 5
-                let res'' = res' {validated = isVal}
+                (res', val_res) <- runValidate (validate_with config) modN entry solver simplifier bindings m' 5
+                let res'' = res' {validate_result = val_res}
 
-                liftIO $ do
-                    printStateOutput config entry_id bindings (Just isVal) m'
+                printStateOutput config entry_id bindings (Just val_res) m'
 
                 return (SAT (res'', ng))
         SAT (m, _) -> do
-            liftIO $ printStateOutput config entry_id bindings Nothing m
+            printStateOutput config entry_id bindings Nothing m
             return res
+
         _ -> return res
 
 runValidate :: ( MonadIO m
@@ -878,26 +878,25 @@ runValidate :: ( MonadIO m
                 -> Bindings 
                 -> ExecRes t 
                 -> Int 
-                -> m (ExecRes t, Maybe Bool)
-runValidate _ _ _ _ _ _ res 0 = return (res, Nothing)
+                -> m (ExecRes t, ValidateRes)
+runValidate _ _ _ _ _ _ res 0 = return (res, Invalid)
 runValidate val_with modN entry solver simplifier bindings 
         res@ExecRes{final_state = fs} runLimit = do
-    isValidated <- validateState val_with modN entry [] [] bindings res 
+    validate_res <- validateState val_with modN entry [] [] bindings res 
     let currModel = model fs
         eenv = expr_env fs
         tv = tyvar_env fs
         origPc = path_conds fs
-    case isValidated of
-        Nothing -> do
+    case validate_res of
+        ValidationTimeout -> do
             let (eenv', pcs) = getNewPathCond (HM.toList currModel) tv eenv
                 newPc = makePathConds pcs origPc
                 fs' = fs {expr_env = eenv', path_conds = newPc}
             res' <- runG2Solving solver simplifier fs' bindings
             case res' of
                 SAT (m, !_) -> runValidate val_with modN entry solver simplifier bindings m (runLimit - 1)
-                _ -> return (res, isValidated)
-        _ -> return (res, isValidated)
-
+                _ -> return (res, validate_res)
+        _ -> return (res, validate_res)
     where 
         getNewPathCond ((n, e):nes) tvenv expEnv = 
             let ty = typeOf tvenv e
@@ -941,7 +940,7 @@ runG2SubstModel m s@(State { expr_env = eenv, type_env = tenv, tyvar_env = tv_en
                      , conc_mutvars = mv
                      , conc_handles = h
                      , violated = ais
-                     , validated = Nothing }
+                     , validate_result = Invalid }
 
         sm' = runPostprocessing bindings sm
 
@@ -952,7 +951,7 @@ runG2SubstModel m s@(State { expr_env = eenv, type_env = tenv, tyvar_env = tv_en
                        , conc_mutvars = mv
                        , conc_handles = conc_handles sm'
                        , violated = evalPrims eenv tenv tv_env kv tc (violated sm')
-                       , validated = Nothing -- when validate runs, it will get updated
+                       , validate_result = Invalid -- when validate runs, it will get updated
                        }
     in
     sm''

--- a/src/G2/Interface/Interface.hs
+++ b/src/G2/Interface/Interface.hs
@@ -879,7 +879,7 @@ runValidate :: ( MonadIO m
                 -> ExecRes t 
                 -> Int 
                 -> m (ExecRes t, ValidateRes)
-runValidate _ _ _ _ _ _ res 0 = return (res, Invalid)
+runValidate _ _ _ _ _ _ res 0 = return (res, ValidationTimeout)
 runValidate val_with modN entry solver simplifier bindings 
         res@ExecRes{final_state = fs} runLimit = do
     validate_res <- validateState val_with modN entry [] [] bindings res 

--- a/src/G2/Translation/GHC.hs
+++ b/src/G2/Translation/GHC.hs
@@ -22,6 +22,7 @@ module G2.Translation.GHC ( module GHC
                           , module GHC.Types.Id.Info
                           , module GHC.Types.Literal
                           , module GHC.Types.Name
+                          , module GHC.Types.SourceError
                           , module GHC.Types.SrcLoc
                           , module GHC.Types.Unique
                           , module GHC.Types.Var
@@ -85,6 +86,7 @@ import GHC.Types.Avail
 import GHC.Types.Id.Info
 import GHC.Types.Literal
 import GHC.Types.Name hiding (varName)
+import GHC.Types.SourceError
 import GHC.Types.SrcLoc
 import GHC.Types.Unique
 import GHC.Types.Var

--- a/src/G2/Translation/GHC.hs
+++ b/src/G2/Translation/GHC.hs
@@ -16,13 +16,18 @@ module G2.Translation.GHC ( module GHC
                           , module GHC.Data.Pair
                           , module GHC.Driver.Main
                           , module GHC.Driver.Session
+-- 
+#if __GLASGOW_HASKELL__ == 902
+                          , module GHC.Driver.Types
+#else
+                          , module GHC.Types.SourceError
+#endif
                           , module GHC.Iface.Tidy
                           , module GHC.Paths
                           , module GHC.Types.Avail
                           , module GHC.Types.Id.Info
                           , module GHC.Types.Literal
                           , module GHC.Types.Name
-                          , module GHC.Types.SourceError
                           , module GHC.Types.SrcLoc
                           , module GHC.Types.Unique
                           , module GHC.Types.Var
@@ -80,13 +85,17 @@ import GHC.Data.FastString
 import GHC.Data.Pair
 import GHC.Driver.Main
 import GHC.Driver.Session
+#if __GLASGOW_HASKELL__ == 902
+import GHC.Driver.Types
+#else 
+import GHC.Types.SourceError
+#endif
 import GHC.Iface.Tidy
 import GHC.Paths
 import GHC.Types.Avail
 import GHC.Types.Id.Info
 import GHC.Types.Literal
 import GHC.Types.Name hiding (varName)
-import GHC.Types.SourceError
 import GHC.Types.SrcLoc
 import GHC.Types.Unique
 import GHC.Types.Var

--- a/src/G2/Translation/GHC.hs
+++ b/src/G2/Translation/GHC.hs
@@ -17,7 +17,7 @@ module G2.Translation.GHC ( module GHC
                           , module GHC.Driver.Main
                           , module GHC.Driver.Session
 -- 
-#if __GLASGOW_HASKELL__ == 902
+#if __GLASGOW_HASKELL__ == 900 && __GLASGOW_HASKELL_PATCHLEVEL1__ == 2
                           , module GHC.Driver.Types
 #else
                           , module GHC.Types.SourceError
@@ -85,7 +85,7 @@ import GHC.Data.FastString
 import GHC.Data.Pair
 import GHC.Driver.Main
 import GHC.Driver.Session
-#if __GLASGOW_HASKELL__ == 902
+#if __GLASGOW_HASKELL__ == 900 && __GLASGOW_HASKELL_PATCHLEVEL1__ == 2
 import GHC.Driver.Types
 #else 
 import GHC.Types.SourceError

--- a/src/G2/Translation/ValidateState.hs
+++ b/src/G2/Translation/ValidateState.hs
@@ -100,23 +100,25 @@ creatDeclStr _ _ _ = error "creatDeclStr: unsupported AlgDataTy"
 -- | Compile with GHC, and check that the output we got is correct for the input
 validateStatesGHC :: GhcMonad m => PrettyGuide -> String -> HS.HashSet (Maybe T.Text) -> String -> [String] -> [String] -> Bindings -> ExecRes t -> m (ValidateRes, [Bool])
 validateStatesGHC pg comp_func modN entry chAll chAny b er@(ExecRes {final_state = s, conc_out = out}) = do
-    ((maybe_v, maybe_se), chAllR, chAnyR) <- runCheck pg comp_func modN entry chAll chAny b er
+    (chck_res, chAllR, chAnyR) <- runCheck pg comp_func modN entry chAll chAny b er
     
-    v' <- case maybe_v of 
-            Just v -> liftIO . timeout (5 * 10 * 1000) $ (unsafeCoerce v :: IO (Either SomeException Bool))
-            Nothing -> return Nothing
+    -- If check result is an HVal, coerce to an exception or a Bool. Additionally, track if the check result was a SrcErr.
+    m_val_or_except <- case chck_res of 
+            HVal v -> liftIO . timeout (5 * 10 * 1000) $ (unsafeCoerce v :: IO (Either SomeException Bool))
+            SrcErr _ -> return Nothing
 
     let outStr = T.unpack $ printHaskell s out
+   
+    -- Translate to ValidateRes
+    let val_res = case m_val_or_except of
+            Nothing -> ValidationSrcError (case chck_res of SrcErr se -> se; _ -> error "validateStatesGHC: source error flagged but no available SourceError object")
+            Just (Left e) | show e == "<<timeout>>" -> ValidationTimeout
+                          | otherwise -> ValidationRTError
+            Just (Right b) -> if b && outStr /= "error" && outStr /= "undefined" then Valid else Invalid
 
-    -- TOOD[Jacob]: should have better way of translating to ValidateRes
-    let v'' = case v' of
-                    Nothing -> ValidationSrcError (case maybe_se of Just se -> se; Nothing -> error "validateStatesGHC: source error flagged but no available SourceError object")
-                    Just (Left e) | show e == "<<timeout>>" -> ValidationTimeout
-                                  | otherwise -> ValidationRTError
-                    Just (Right b) -> if b && outStr /= "error" && outStr /= "undefined" then Valid else Invalid
-
-    -- TODO[Jacob]: this a quick solution distinguish real runtime errors from expected runtime errors
-    let v''' = case v'' of 
+    -- TODO[Jacob]: Currently using ValidationRTError to mean "a runtime error that was not the desired result of validation".
+    -- If both symbolic execution and GHC validation found a runtime error, convert the ValidateRes to Valid.
+    let val_res' = case val_res of 
             ValidationRTError -> if errorRaised s then Valid else ValidationRTError
             v -> v 
 
@@ -126,11 +128,11 @@ validateStatesGHC pg comp_func modN entry chAll chAny b er@(ExecRes {final_state
     chAnyR' <- liftIO $ (mapM unsafeCoerce chAnyR :: IO [Either SomeException Bool])
     let chAnyR'' = rights chAnyR'
 
-    let v'''' = case (v''', and chAllR'') of
+    let val_res'' = case (val_res', and chAllR'') of
                     (Valid, False) -> Invalid
                     (v_res, _) -> v_res
 
-    return (v'''', chAnyR'')
+    return (val_res'', chAnyR'')
 
 createDeclsStr :: PrettyGuide -> State t -> TypeEnv -> [String]
 createDeclsStr pg s = map (creatDeclStr pg s) . H.toList
@@ -147,7 +149,9 @@ adjustDynFlags = do
     _ <- setSessionDynFlags dyn4
     return ()
 
-runCheck :: GhcMonad m => PrettyGuide -> String -> HS.HashSet (Maybe T.Text) -> String -> [String] -> [String] -> Bindings -> ExecRes t -> m ((Maybe HValue, Maybe SourceError), [HValue], [HValue])
+data CheckRes = HVal HValue | SrcErr SourceError
+
+runCheck :: GhcMonad m => PrettyGuide -> String -> HS.HashSet (Maybe T.Text) -> String -> [String] -> [String] -> Bindings -> ExecRes t -> m (CheckRes, [HValue], [HValue])
 runCheck init_pg comp_func modN entry chAll chAny b er@(ExecRes {final_state = s, conc_args = ars, conc_out = out}) = do
     let Left (v, _) = findFunc (tyvar_env s) (T.pack entry) (HS.toList modN) (expr_env s)
     let e = mkApp $ Var v:ars
@@ -183,10 +187,10 @@ runCheck init_pg comp_func modN entry chAll chAny b er@(ExecRes {final_state = s
                     True -> mvStr ++ "Control.Exception.try (evaluate ( (" ++ pr_con ++ "(" ++ arsStr ++ " :: " ++ arsType ++ ")" ++
                                                     ") " ++ comp_func' ++ " " ++ pr_con ++ "(" ++ arsStr ++ "))) :: IO (Either SomeException Bool)"
 
-    -- TODO: disambiguate between SourceError and runtime error
-    (maybe_v', maybe_se) <- defaultErrorHandler defaultFatalMessager defaultFlushOut
-            $ handleSourceError (\err -> return (Nothing, Just err)) 
-                                (do v_ <- compileExpr chck; return (Just v_, Nothing))
+    -- TODO[Jacob]: Currently determining source error here and runtime error later. Consider changing
+    chck_res <- defaultErrorHandler defaultFatalMessager defaultFlushOut
+            $ handleSourceError (\err -> return $ SrcErr err) 
+                                (do hv <- compileExpr chck; return $ HVal hv)
 
     let chArgs = ars ++ [out] 
     let chAllStr = map (\f -> T.unpack $ printHaskellPG pg s $ mkApp ((simpVar $ T.pack f):chArgs)) chAll
@@ -199,7 +203,7 @@ runCheck init_pg comp_func modN entry chAll chAny b er@(ExecRes {final_state = s
 
     chAnyR <- mapM compileExpr chAnyStr'
 
-    return ((maybe_v', maybe_se), chAllR, chAnyR)
+    return (chck_res, chAllR, chAnyR)
 
 loadToCheck :: GhcMonad m => [FilePath] -> [FilePath] -> HS.HashSet (Maybe T.Text) -> [GeneralFlag] -> m ()
 loadToCheck proj src modN gflags = do
@@ -342,23 +346,24 @@ printStateOutput :: (GhcMonad m) => Config -> Id -> Bindings
                -> ExecRes t
                -> m ()
 printStateOutput config entry b mval_res exec_res@(ExecRes { final_state = s }) = do
-    let print_valid = isJust mval_res
-
     let pg = mkPrettyGuide (exprNames $ conc_args exec_res)
     let (mvp, inp, outp, handles) = printInputOutput pg entry b exec_res
-        sym_gen_out = printHaskellPG pg s <$> conc_sym_gens exec_res
+        sym_gen_out = fmap (printHaskellPG pg s) $ conc_sym_gens exec_res
         
     let print_method m i o = m <> i <> " = " <> o
 
     let state_output_text = print_method mvp inp outp
 
+    let print_valid = isJust mval_res
     when (print_output config) (do
         when print_valid $ do
-            (case fromMaybe Invalid mval_res of
+            let val_res = fromJust mval_res -- know mval_res is Just, can use fromJust
+
+            (case val_res of
                 ValidationSrcError vse -> printException vse
                 _ -> return ())
             
-            liftIO (case fromMaybe Invalid mval_res of
+            liftIO (case val_res of
                 Valid -> putStr "✓ "
                 Invalid -> putStr "✗ "
                 ValidationTimeout -> putStr "✗TO "

--- a/src/G2/Translation/ValidateState.hs
+++ b/src/G2/Translation/ValidateState.hs
@@ -28,7 +28,7 @@ import GHC.LanguageExtensions
 import GHC.Paths
 import Control.Monad
 
-import GHC.Types.SourceError
+import G2.Translation.GHC (SourceError)
 
 import Data.Foldable (toList)
 import Data.Either

--- a/src/G2/Translation/ValidateState.hs
+++ b/src/G2/Translation/ValidateState.hs
@@ -28,6 +28,8 @@ import GHC.LanguageExtensions
 import GHC.Paths
 import Control.Monad
 
+import GHC.Types.SourceError
+
 import Data.Foldable (toList)
 import Data.Either
 import qualified Data.HashSet as HS
@@ -60,8 +62,7 @@ import Control.Monad.IO.Class
 -- | Load the passed module(s) into GHC, and check that the `ExecRes` results are correct.
 validateStates :: [FilePath] -> [FilePath] -> HS.HashSet (Maybe T.Text) -> String -> [String] -> [String] -> [GeneralFlag] -> String -> Bindings
                -> [ExecRes t]
-               -> IO ( [Maybe Bool] -- ^ One bool per input `ExecRes`, indicating whether the results are correct or not
-                                  -- Nothing in the case of a timeout
+               -> IO ( [ValidateRes]
                      , Bool -- ^ Are all "Any" requirements satisfied?
                      )
 validateStates proj src modN entry chAll chAny gflags comp_func b in_out = do
@@ -97,17 +98,20 @@ creatDeclStr pg s (x, DataTyCon{data_cons = dcs, bound_ids = is}) =
 creatDeclStr _ _ _ = error "creatDeclStr: unsupported AlgDataTy"
 
 -- | Compile with GHC, and check that the output we got is correct for the input
-validateStatesGHC :: GhcMonad m => PrettyGuide -> String -> HS.HashSet (Maybe T.Text) -> String -> [String] -> [String] -> Bindings -> ExecRes t -> m (Maybe Bool, [Bool])
+validateStatesGHC :: GhcMonad m => PrettyGuide -> String -> HS.HashSet (Maybe T.Text) -> String -> [String] -> [String] -> Bindings -> ExecRes t -> m (ValidateRes, [Bool])
 validateStatesGHC pg comp_func modN entry chAll chAny b er@(ExecRes {final_state = s, conc_out = out}) = do
-    (v, chAllR, chAnyR) <- runCheck pg comp_func modN entry chAll chAny b er
+    ((maybe_v, maybe_se), chAllR, chAnyR) <- runCheck pg comp_func modN entry chAll chAny b er
+    
+    v' <- case maybe_v of 
+            Just v -> liftIO . timeout (5 * 10 * 1000) $ (unsafeCoerce v :: IO (Either SomeException Bool))
+            Nothing -> return Nothing
 
-    v' <- liftIO . timeout (5 * 10 * 1000) $ (unsafeCoerce v :: IO (Either SomeException Bool))
     let outStr = T.unpack $ printHaskell s out
     let v'' = case v' of
-                    Nothing -> Nothing
-                    Just (Left e) | show e == "<<timeout>>" -> Nothing
-                                  | otherwise -> Just $ errorRaised s
-                    Just (Right b) -> Just (b && outStr /= "error" && outStr /= "undefined")
+                    Nothing -> ValidationSrcError (case maybe_se of Just se -> se; Nothing -> error "validateStatesGHC: source error flagged but no available SourceError object")
+                    Just (Left e) | show e == "<<timeout>>" -> ValidationTimeout
+                                  | otherwise -> ValidationRTError
+                    Just (Right b) -> if b && outStr /= "error" && outStr /= "undefined" then Valid else Invalid
 
     chAllR' <- liftIO $ (mapM unsafeCoerce chAllR :: IO [Either SomeException Bool])
     let chAllR'' = rights chAllR'
@@ -115,7 +119,11 @@ validateStatesGHC pg comp_func modN entry chAll chAny b er@(ExecRes {final_state
     chAnyR' <- liftIO $ (mapM unsafeCoerce chAnyR :: IO [Either SomeException Bool])
     let chAnyR'' = rights chAnyR'
 
-    return $ (fmap (&& and chAllR'') v'', chAnyR'')
+    let v''' = case (v'', and chAllR'') of
+                    (Valid, False) -> Invalid
+                    (v_res, _) -> v_res
+
+    return (v''', chAnyR'')
 
 createDeclsStr :: PrettyGuide -> State t -> TypeEnv -> [String]
 createDeclsStr pg s = map (creatDeclStr pg s) . H.toList
@@ -132,7 +140,7 @@ adjustDynFlags = do
     _ <- setSessionDynFlags dyn4
     return ()
 
-runCheck :: GhcMonad m => PrettyGuide -> String -> HS.HashSet (Maybe T.Text) -> String -> [String] -> [String] -> Bindings -> ExecRes t -> m (HValue, [HValue], [HValue])
+runCheck :: GhcMonad m => PrettyGuide -> String -> HS.HashSet (Maybe T.Text) -> String -> [String] -> [String] -> Bindings -> ExecRes t -> m ((Maybe HValue, Maybe SourceError), [HValue], [HValue])
 runCheck init_pg comp_func modN entry chAll chAny b er@(ExecRes {final_state = s, conc_args = ars, conc_out = out}) = do
     let Left (v, _) = findFunc (tyvar_env s) (T.pack entry) (HS.toList modN) (expr_env s)
     let e = mkApp $ Var v:ars
@@ -141,6 +149,7 @@ runCheck init_pg comp_func modN entry chAll chAny b er@(ExecRes {final_state = s
            $ updatePGValAndTypeNames (varIds v) init_pg
 
     let (mvTxt, arsTxt, outTxt, _) = printInputOutput pg v b er 
+
         mvStr = T.unpack mvTxt
         arsStr = T.unpack arsTxt
         outStr = T.unpack outTxt
@@ -167,7 +176,11 @@ runCheck init_pg comp_func modN entry chAll chAny b er@(ExecRes {final_state = s
                                         ++ outStr ++ outType ++ ")" ++ ")) :: IO (Either SomeException Bool)"
                     True -> mvStr ++ "Control.Exception.try (evaluate ( (" ++ pr_con ++ "(" ++ arsStr ++ " :: " ++ arsType ++ ")" ++
                                                     ") " ++ comp_func' ++ " " ++ pr_con ++ "(" ++ arsStr ++ "))) :: IO (Either SomeException Bool)"
-    v' <- compileExpr chck
+
+    -- TODO: disambiguate between SourceError and runtime error
+    (maybe_v', maybe_se) <- defaultErrorHandler defaultFatalMessager defaultFlushOut
+            $ handleSourceError (\err -> return (Nothing, Just err)) 
+                                (do v_ <- compileExpr chck; return (Just v_, Nothing))
 
     let chArgs = ars ++ [out] 
     let chAllStr = map (\f -> T.unpack $ printHaskellPG pg s $ mkApp ((simpVar $ T.pack f):chArgs)) chAll
@@ -180,7 +193,7 @@ runCheck init_pg comp_func modN entry chAll chAny b er@(ExecRes {final_state = s
 
     chAnyR <- mapM compileExpr chAnyStr'
 
-    return $ (v', chAllR, chAnyR)
+    return ((maybe_v', maybe_se), chAllR, chAnyR)
 
 loadToCheck :: GhcMonad m => [FilePath] -> [FilePath] -> HS.HashSet (Maybe T.Text) -> [GeneralFlag] -> m ()
 loadToCheck proj src modN gflags = do
@@ -305,9 +318,7 @@ loadSession proj src modN gflags = do
 -- | Load the passed module(s) into GHC, and check that the `ExecRes` results are correct.
 validateState :: GhcMonad m => String -> HS.HashSet (Maybe T.Text) -> String -> [String] -> [String] -> Bindings
                -> ExecRes t
-               -> m ( Maybe Bool -- ^ One bool per input `ExecRes`, indicating whether the results are correct or not
-                                  -- Nothing in the case of a timeout
-                     )
+               -> m ValidateRes
 validateState comp_func modN entry chAll chAny b in_out = do
         let s = final_state in_out
         let pg = updatePGValNames (concatMap (map Data . dataCon) $ type_env s)
@@ -320,31 +331,39 @@ validateState comp_func modN entry chAll chAny b in_out = do
         
         return (fst rs_anys)
 
-printStateOutput :: Config -> Id -> Bindings
-               -> Maybe (Maybe Bool)
+printStateOutput :: (GhcMonad m) => Config -> Id -> Bindings
+               -> Maybe ValidateRes
                -> ExecRes t
-               -> IO ()
-printStateOutput config entry b m_valid exec_res@(ExecRes { final_state = s }) = do
-    let print_valid = isJust m_valid
-    let val = fromMaybe (Just True) m_valid
-
-    when print_valid (putStr (case val of
-                                        Just True -> "✓ "
-                                        Just False -> "✗ "
-                                        Nothing -> "✗TO "))
+               -> m ()
+printStateOutput config entry b mval_res exec_res@(ExecRes { final_state = s }) = do
+    let print_valid = isJust mval_res
 
     let pg = mkPrettyGuide (exprNames $ conc_args exec_res)
     let (mvp, inp, outp, handles) = printInputOutput pg entry b exec_res
-        sym_gen_out = fmap (printHaskellPG pg s) $ conc_sym_gens exec_res
+        sym_gen_out = printHaskellPG pg s <$> conc_sym_gens exec_res
         
-    let print_method = \m i o -> m <> i <> " = " <> o 
+    let print_method m i o = m <> i <> " = " <> o
 
-    when (print_output config ) (do
-        case sym_gen_out of
-            S.Empty -> T.putStrLn $ print_method mvp inp outp
-            _ -> T.putStrLn $ print_method mvp inp outp <> "\t| generated: " <> T.intercalate ", " (toList sym_gen_out)
-        if handles /= "" then T.putStrLn handles else return ())
+    let state_output_text = print_method mvp inp outp
 
+    when (print_output config) (do
+        when print_valid $ do
+            (case fromMaybe Invalid mval_res of
+                ValidationSrcError vse -> printException vse
+                _ -> return ())
+            
+            liftIO (case fromMaybe Invalid mval_res of
+                Valid -> putStr "✓ "
+                Invalid -> putStr "✗ "
+                ValidationTimeout -> putStr "✗TO "
+                ValidationSrcError _ -> putStr "✗Src "
+                ValidationRTError -> putStr "✗RT ")
+        
+        liftIO $ case sym_gen_out of
+            S.Empty -> T.putStrLn state_output_text
+            _ -> T.putStrLn $ state_output_text <> "\t| generated: " <> T.intercalate ", " (toList sym_gen_out)
+        
+        liftIO $ if handles /= "" then T.putStrLn handles else return ())
 
 toEnclodeFloat :: ASTContainer m Expr => m -> m
 toEnclodeFloat = modifyASTs go

--- a/src/G2/Translation/ValidateState.hs
+++ b/src/G2/Translation/ValidateState.hs
@@ -156,7 +156,6 @@ runCheck init_pg comp_func modN entry chAll chAny b er@(ExecRes {final_state = s
            $ updatePGValAndTypeNames (varIds v) init_pg
 
     let (mvTxt, arsTxt, outTxt, _) = printInputOutput pg v b er 
-
         mvStr = T.unpack mvTxt
         arsStr = T.unpack arsTxt
         outStr = T.unpack outTxt

--- a/src/G2/Translation/ValidateState.hs
+++ b/src/G2/Translation/ValidateState.hs
@@ -107,11 +107,18 @@ validateStatesGHC pg comp_func modN entry chAll chAny b er@(ExecRes {final_state
             Nothing -> return Nothing
 
     let outStr = T.unpack $ printHaskell s out
+
+    -- TOOD[Jacob]: should have better way of translating to ValidateRes
     let v'' = case v' of
                     Nothing -> ValidationSrcError (case maybe_se of Just se -> se; Nothing -> error "validateStatesGHC: source error flagged but no available SourceError object")
                     Just (Left e) | show e == "<<timeout>>" -> ValidationTimeout
                                   | otherwise -> ValidationRTError
                     Just (Right b) -> if b && outStr /= "error" && outStr /= "undefined" then Valid else Invalid
+
+    -- TODO[Jacob]: this a quick solution distinguish real runtime errors from expected runtime errors
+    let v''' = case v'' of 
+            ValidationRTError -> if errorRaised s then Valid else ValidationRTError
+            v -> v 
 
     chAllR' <- liftIO $ (mapM unsafeCoerce chAllR :: IO [Either SomeException Bool])
     let chAllR'' = rights chAllR'
@@ -119,11 +126,11 @@ validateStatesGHC pg comp_func modN entry chAll chAny b er@(ExecRes {final_state
     chAnyR' <- liftIO $ (mapM unsafeCoerce chAnyR :: IO [Either SomeException Bool])
     let chAnyR'' = rights chAnyR'
 
-    let v''' = case (v'', and chAllR'') of
+    let v'''' = case (v''', and chAllR'') of
                     (Valid, False) -> Invalid
                     (v_res, _) -> v_res
 
-    return (v''', chAnyR'')
+    return (v'''', chAnyR'')
 
 createDeclsStr :: PrettyGuide -> State t -> TypeEnv -> [String]
 createDeclsStr pg s = map (creatDeclStr pg s) . H.toList

--- a/src/G2/Verify/Interface.hs
+++ b/src/G2/Verify/Interface.hs
@@ -36,7 +36,7 @@ import qualified G2.Language.TyVarEnv as TV
 data VerifyResult = Verified
                   | Counterexample [ExecRes VerifierTracker]
                   | VerifyTimeOut
-                  deriving (Show, Read)
+                  deriving (Show)
 
 type VerStack m = SM.StateT LemmaInfo
                     (SM.StateT (ApproxPrevs VerifierTracker)

--- a/tests/FuzzExecution.hs
+++ b/tests/FuzzExecution.hs
@@ -52,7 +52,7 @@ fuzzExecution (SB init_state bindings) = do
                                     -- Actually validate
                                     let mods = HS.singleton Nothing
                                     (val, _) <- validateStatesGHC pg "==" mods "call" [] [] b er
-                                    return $ fromMaybe False val) ers
+                                    return $ transValidateRes val) ers
             )
         
         -- Get information about generated input/outputs when test fails

--- a/tests/FuzzExecution.hs
+++ b/tests/FuzzExecution.hs
@@ -52,7 +52,8 @@ fuzzExecution (SB init_state bindings) = do
                                     -- Actually validate
                                     let mods = HS.singleton Nothing
                                     (val, _) <- validateStatesGHC pg "==" mods "call" [] [] b er
-                                    return $ transValidateRes val) ers
+                                    let isValid = case val of Valid -> True; _ -> False
+                                    return isValid) ers
             )
         
         -- Get information about generated input/outputs when test fails

--- a/tests/HigherOrder/RankN.hs
+++ b/tests/HigherOrder/RankN.hs
@@ -63,3 +63,9 @@ partiallyApply f = let pApp = f 1
 twoTVsMultiCall :: (forall a b. a -> b -> b) -> Int 
 twoTVsMultiCall f = case (f 1 2, f 3 4) of 
                         (2, 4) -> f 5 6
+
+-- Generates def that uses typeclass internals and shouldn't validate
+tcFunc :: (forall a. (Eq a) => a -> a) -> Int
+tcFunc f = case f 1 of
+                1 -> 2
+                _ -> 3

--- a/tests/HigherOrder/RankN.hs
+++ b/tests/HigherOrder/RankN.hs
@@ -64,7 +64,10 @@ twoTVsMultiCall :: (forall a b. a -> b -> b) -> Int
 twoTVsMultiCall f = case (f 1 2, f 3 4) of 
                         (2, 4) -> f 5 6
 
--- Generates def that uses typeclass internals and shouldn't validate
+-- TODO[Jacob]: Not actual test case. Included to demonstrate changes made to 
+-- validation. This will currently produce a definition which shows type class 
+-- internals, leading to a Haskell source error, which will now NOT lead to 
+-- validation halting. Will remove eventually.
 tcFunc :: (forall a. (Eq a) => a -> a) -> Int
 tcFunc f = case f 1 of
                 1 -> 2

--- a/tests/InputOutputTest.hs
+++ b/tests/InputOutputTest.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings, LambdaCase #-}
 module InputOutputTest ( checkInputOutput
                        , checkInputOutputs
                        , checkInputOutputsWithCVC5
@@ -23,9 +23,7 @@ module InputOutputTest ( checkInputOutput
                        , checkInputOutputsNonRedLib
                        , checkInputOutputsInstType 
                        , checkInputOutputsWithValidate
-                       , checkInputOutputsWithTemplatesAndHpc
-                       
-                       , transValidateRes) where
+                       , checkInputOutputsWithTemplatesAndHpc) where
 
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -246,7 +244,9 @@ checkInputOutput''' adj_config src exg2 nm tnm mb_modname config (entry, stps, r
 
     let chEx = checkExprInOutCount io req
     
-    return (fmap transValidateRes mr, chEx, anys, r, b)
+    let isValids = (\case Valid -> True; _ -> False) <$> mr
+
+    return (isValids, chEx, anys, r, b)
 
 ------------
 

--- a/tests/InputOutputTest.hs
+++ b/tests/InputOutputTest.hs
@@ -23,7 +23,9 @@ module InputOutputTest ( checkInputOutput
                        , checkInputOutputsNonRedLib
                        , checkInputOutputsInstType 
                        , checkInputOutputsWithValidate
-                       , checkInputOutputsWithTemplatesAndHpc) where
+                       , checkInputOutputsWithTemplatesAndHpc
+                       
+                       , transValidateRes) where
 
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -244,7 +246,7 @@ checkInputOutput''' adj_config src exg2 nm tnm mb_modname config (entry, stps, r
 
     let chEx = checkExprInOutCount io req
     
-    return (fmap (fromMaybe False) mr, chEx, anys, r, b)
+    return (fmap transValidateRes mr, chEx, anys, r, b)
 
 ------------
 

--- a/verify/Main.hs
+++ b/verify/Main.hs
@@ -43,7 +43,7 @@ printFuncCalls config entry b exec_res = do
 
         let print_method = case print_output config of
                                 True -> \m i o -> m <> i <> " = " <> o 
-                                False -> \m i _ ->  m <> i
+                                False -> \m i _ -> m <> i
 
         case sym_gen_out of
             S.Empty -> T.putStrLn $ print_method mvp inp outp

--- a/verify/Main.hs
+++ b/verify/Main.hs
@@ -43,7 +43,7 @@ printFuncCalls config entry b exec_res = do
 
         let print_method = case print_output config of
                                 True -> \m i o -> m <> i <> " = " <> o 
-                                False -> \m i _ -> m <> i
+                                False -> \m i _ ->  m <> i
 
         case sym_gen_out of
             S.Empty -> T.putStrLn $ print_method mvp inp outp


### PR DESCRIPTION
Previously, the program would halt when the first source error or runtime error was encountered. Now, the program prints the error (with a more specific "x" mark, such as xSrc, xRT, or xTO) and continues validating other outputs.

A test case, tests/HigherOrder/RankN.hs:tcFunc, which produces invalid Haskell code, will demonstrate this change.