### PR TITLE
More warning cleanup

### DIFF
--- a/src/G2/Translation/ValidateState.hs
+++ b/src/G2/Translation/ValidateState.hs
@@ -13,6 +13,7 @@ module G2.Translation.ValidateState ( validateStates
                                    , printStateOutput
                                    , toEnclodeFloat
                                     ) where
+
 #if MIN_VERSION_GLASGOW_HASKELL(9,0,2,0)
 import GHC.Driver.Session
 import qualified GHC.Data.EnumSet as ES
@@ -37,6 +38,7 @@ import Data.Maybe
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import qualified Data.Sequence as S
+import Text.Regex
 import Unsafe.Coerce
 import qualified Data.HashMap.Lazy as H
 import G2.Config
@@ -212,7 +214,25 @@ loadToCheck proj src modN gflags = do
         let mdN = map (mkModuleName . T.unpack) . catMaybes $ HS.toList modN
         let imD = map simpleImportDecl mdN
 
-        setContext (map IIDecl imD ++ loadStandardSet)
+        imps <- liftIO $ concat <$> mapM getImports src
+
+        let imp_decls = map (IIDecl . simpleImportDecl . mkModuleName) imps
+
+        setContext (map IIDecl imD ++ loadStandardSet ++ imp_decls)
+
+getImports :: FilePath -> IO [String]
+getImports src = do
+    srcCode <- readFile src
+    get srcCode
+    where
+        get str = do
+            -- This also matches "import X as Y", which is fine since the code will need to
+            -- be parsed and it will error there
+            let reg_str = "(^|;[ \t]*)import[ \t]*(qualified[ \t]*)?([a-zA-Z0-9_.]*)([ \t]+as[ \t]+[a-zA-Z0-9_.]*)?"
+            let r = mkRegex reg_str
+            case matchRegexAll r str of
+                Just (_, _, after, [_, _, imp, _]) -> (imp :) <$> get after
+                _ -> return []
 
 loadStandard :: Ghc ()
 loadStandard = setContext loadStandardSet
@@ -251,6 +271,7 @@ runHPC src meas_with modN entry in_out = do
 -- Compile with GHC, and check that the output we got is correct for the input
 runHPC' :: FilePath -> String -> String -> [String] -> IO ()
 runHPC' src meas_with modN ars = do
+    imps <- getImports src
     srcCode <- readFile src
     let ext = dropWhile (/= '.') src
         dir = takeDirectory src
@@ -277,13 +298,16 @@ runHPC' src meas_with modN ars = do
     removeFile (mainMod ++ ".tix") `catch` handleExists
 
     writeFile (origFile ++ ext) srcCode
-    writeFile (mainFile ++ ".hs") ("module CallForHPC where\n\nimport qualified Control.Exception as Ex\nimport Data.Char\nimport " ++ modN ++ "\n" ++ mainFunc)
+    let main_imps = intercalate "\n" $ map ("import " ++) imps
+    writeFile (mainFile ++ ".hs") ("module CallForHPC where\n\nimport qualified Control.Exception as Ex\nimport Data.Char\nimport " ++ modN ++ "\n" ++ main_imps ++ "\n" ++ mainFunc)
 
     callProcess "ghc" $ ["-main-is", "CallForHPC.main_internal_g2", "-fhpc"
                         , mainFile ++ ".hs", src, "-o", mainFile, "-O0", "-i" ++ dir]
     callProcess ("./" ++ mainFile) []
 
     callProcess "hpc" ["report", mainMod, "--per-module", "--srcdir=hpc", "--hpcdir=../.hpc"]
+
+    -- putStrLn mainFunc
 
 toCall :: String -> String -> State t -> [Expr] -> Expr -> String
 toCall modN entry s ars _ =

--- a/src/G2/Translation/ValidateState.hs
+++ b/src/G2/Translation/ValidateState.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, CPP, FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings, CPP, FlexibleContexts, BangPatterns #-}
 
 module G2.Translation.ValidateState ( validateStates
                                    , validateStatesGHC
@@ -13,7 +13,6 @@ module G2.Translation.ValidateState ( validateStates
                                    , printStateOutput
                                    , toEnclodeFloat
                                     ) where
-
 #if MIN_VERSION_GLASGOW_HASKELL(9,0,2,0)
 import GHC.Driver.Session
 import qualified GHC.Data.EnumSet as ES
@@ -214,25 +213,7 @@ loadToCheck proj src modN gflags = do
         let mdN = map (mkModuleName . T.unpack) . catMaybes $ HS.toList modN
         let imD = map simpleImportDecl mdN
 
-        imps <- liftIO $ concat <$> mapM getImports src
-
-        let imp_decls = map (IIDecl . simpleImportDecl . mkModuleName) imps
-
-        setContext (map IIDecl imD ++ loadStandardSet ++ imp_decls)
-
-getImports :: FilePath -> IO [String]
-getImports src = do
-    srcCode <- readFile src
-    get srcCode
-    where
-        get str = do
-            -- This also matches "import X as Y", which is fine since the code will need to
-            -- be parsed and it will error there
-            let reg_str = "^import[ \t]*(qualified[ \t]*)?([a-zA-Z0-9_.]*)([ \t]+as[ \t]+[a-zA-Z0-9_.]*)?"
-            let r = mkRegex reg_str
-            case matchRegexAll r str of
-                Just (_, _, after, [_, imp, _]) -> (imp :) <$> get after
-                _ -> return []
+        setContext (map IIDecl imD ++ loadStandardSet)
 
 loadStandard :: Ghc ()
 loadStandard = setContext loadStandardSet
@@ -271,7 +252,6 @@ runHPC src meas_with modN entry in_out = do
 -- Compile with GHC, and check that the output we got is correct for the input
 runHPC' :: FilePath -> String -> String -> [String] -> IO ()
 runHPC' src meas_with modN ars = do
-    imps <- getImports src
     srcCode <- readFile src
     let ext = dropWhile (/= '.') src
         dir = takeDirectory src
@@ -298,16 +278,13 @@ runHPC' src meas_with modN ars = do
     removeFile (mainMod ++ ".tix") `catch` handleExists
 
     writeFile (origFile ++ ext) srcCode
-    let main_imps = intercalate "\n" $ map ("import " ++) imps
-    writeFile (mainFile ++ ".hs") ("module CallForHPC where\n\nimport qualified Control.Exception as Ex\nimport Data.Char\nimport " ++ modN ++ "\n" ++ main_imps ++ "\n" ++ mainFunc)
+    writeFile (mainFile ++ ".hs") ("module CallForHPC where\n\nimport qualified Control.Exception as Ex\nimport Data.Char\nimport " ++ modN ++ "\n" ++ mainFunc)
 
     callProcess "ghc" $ ["-main-is", "CallForHPC.main_internal_g2", "-fhpc"
                         , mainFile ++ ".hs", src, "-o", mainFile, "-O0", "-i" ++ dir]
     callProcess ("./" ++ mainFile) []
 
     callProcess "hpc" ["report", mainMod, "--per-module", "--srcdir=hpc", "--hpcdir=../.hpc"]
-
-    -- putStrLn mainFunc
 
 toCall :: String -> String -> State t -> [Expr] -> Expr -> String
 toCall modN entry s ars _ =

--- a/src/G2/Translation/ValidateState.hs
+++ b/src/G2/Translation/ValidateState.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, CPP, FlexibleContexts, BangPatterns #-}
+{-# LANGUAGE OverloadedStrings, CPP, FlexibleContexts #-}
 
 module G2.Translation.ValidateState ( validateStates
                                    , validateStatesGHC
@@ -37,7 +37,6 @@ import Data.Maybe
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import qualified Data.Sequence as S
-import Text.Regex
 import Unsafe.Coerce
 import qualified Data.HashMap.Lazy as H
 import G2.Config

--- a/tests/BaseTests/ListTests.hs
+++ b/tests/BaseTests/ListTests.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE BangPatterns, MultiWayIf #-}
+{-# OPTIONS_GHC -Wno-x-partial #-}
+{-# OPTIONS_GHC -Wno-unrecognised-warning-flags #-}
 
 module ListTests where
 

--- a/tests/BaseTests/ZipList.hs
+++ b/tests/BaseTests/ZipList.hs
@@ -1,5 +1,7 @@
 module ZipList where
 
+-- Testing that multi-line imports work with state
+-- validation.
 import Data.Maybe (); import Control.Applicative
 
 callApp :: ZipList Int -> ZipList Int

--- a/tests/BaseTests/ZipList.hs
+++ b/tests/BaseTests/ZipList.hs
@@ -1,6 +1,6 @@
 module ZipList where
 
-import Control.Applicative
+import Data.Maybe (); import Control.Applicative
 
 callApp :: ZipList Int -> ZipList Int
 callApp = (<*>) funcList

--- a/tests/FuzzExecution.hs
+++ b/tests/FuzzExecution.hs
@@ -11,7 +11,6 @@ import G2.Translation
 
 import qualified Data.HashMap.Lazy as HM
 import qualified Data.HashSet as HS
-import Data.Maybe
 import qualified Data.Text as T
 
 import GHC hiding (Name, entry)

--- a/tests/InputOutputTest.hs
+++ b/tests/InputOutputTest.hs
@@ -3,7 +3,7 @@ module InputOutputTest ( checkInputOutput
                        , checkInputOutputs
                        , checkInputOutputsWithCVC5
                        , checkInputOutputsADTHeight
-                       
+
                        , checkInputOutputsSMTStrings
                        , checkInputOutputsWithCVC5SMTStrings
                        , checkInputOutputsSMTStringsStrict
@@ -16,7 +16,7 @@ module InputOutputTest ( checkInputOutput
                        , checkInputOutputsSMTListsWith
                        , checkInputOutputsLambdaSMTLists
                        , checkInputOutputsLitTablesSMTLists
-                       
+
                        , checkInputOutputsTemplate
                        , checkInputOutputsWith
                        , checkInputOutputsNonRedHigher
@@ -25,7 +25,7 @@ module InputOutputTest ( checkInputOutput
                        , checkInputOutputsSymFuncConstraints
                        , checkInputOutputsSymFuncConstraintsFCArgStepLimit
                        , checkInputOutputsSymFuncConstraintsSubPathSMTLists
-                       , checkInputOutputsInstType 
+                       , checkInputOutputsInstType
                        , checkInputOutputsWithValidate
                        , checkInputOutputsWithTemplatesAndHpc) where
 
@@ -33,14 +33,10 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 import Control.Exception
-import Data.IORef
 import qualified Data.HashSet as HS
 import Data.List
-import qualified Data.Map.Lazy as M
-import Data.Maybe
 import qualified Data.Text as T
 import System.FilePath
-import System.IO.Unsafe
 import qualified G2.Language.TyVarEnv as TV
 import G2.Config
 import G2.Initialization.MkCurrExpr

--- a/tests/RewriteVerify/RewriteVerifyTest.hs
+++ b/tests/RewriteVerify/RewriteVerifyTest.hs
@@ -2,8 +2,6 @@
 
 module RewriteVerify.RewriteVerifyTest ( rewriteTests ) where
 
-import qualified Data.Map as M
-import Data.Maybe
 import qualified Data.Text as T
 
 import G2.Config
@@ -13,7 +11,6 @@ import G2.Translation
 
 import G2.Equiv.Config
 import G2.Equiv.Verifier
-import G2.Equiv.Summary
 
 import Data.List
 

--- a/tests/Samples/NQueens.hs
+++ b/tests/Samples/NQueens.hs
@@ -1,3 +1,6 @@
+{-# OPTIONS_GHC -Wno-x-partial #-}
+{-# OPTIONS_GHC -Wno-unrecognised-warning-flags #-}
+
 module NQueens where
 
 import Data.List

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE CPP, DeriveDataTypeable, FlexibleContexts, LambdaCase, OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
 module Main where
 
@@ -23,11 +25,9 @@ import Data.Tagged
 import qualified Data.Text as T
 import System.Environment
 import System.FilePath
-import Type.Reflection (Typeable)
 
 import PeanoTest
 import HigherOrderMathTest
-import GetNthTest
 import DefuncTest
 import FuzzExecution
 import CaseTest
@@ -47,7 +47,6 @@ import Reqs
 import TestUtils
 
 import Data.List
-import qualified Data.Map.Lazy as M
 
 -- Run with no arguments for default test cases.
 -- All default test cases should pass.
@@ -1222,7 +1221,7 @@ todoTests = testGroup "To Do"
 
 data ToDo = RunMain
           | RunToDo
-          deriving (Eq, Typeable)
+          deriving (Eq)
 
 
 instance IsOption ToDo where
@@ -1336,7 +1335,7 @@ checkExprWithConfig src m_assume m_assert m_reaches entry reqList config_f = do
     testCase (src ++ " " ++ entry) (do
         config <- config_f
         res <- testFile src m_assume m_assert m_reaches entry config
-        
+
         let (reqRes, res_print) =
                 case res of
                     Left _ -> (Nothing, [])
@@ -1346,9 +1345,9 @@ checkExprWithConfig src m_assume m_assert m_reaches entry reqList config_f = do
 
                                 pg = mkPrettyGuide exec_res
                                 res_pretty = map (printInputOutput pg (Id (Name (T.pack entry) Nothing 0 Nothing) TyUnknown) b) exec_res
-                                res_print = map T.unpack $ map (\(_, inp, out, _) -> inp <> " = " <> out) res_pretty
+                                res_print_ = map T.unpack $ map (\(_, inp, out, _) -> inp <> " = " <> out) res_pretty
                             in
-                            (Just reqs, res_print)
+                            (Just reqs, res_print_)
 
 
 

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -538,7 +538,9 @@ testFileTests = testGroup "TestFiles"
                                         , ("reverse1", 5000, [AtLeast 5, AtMost 6]) 
                                         , ("reverse2", 5000, [Exactly 3])
                                         , ("insert1", 3000, [AtLeast 2, AtMost 6]) -- Quantifier causes SMT failures
-                                        , ("intersperse1", 3000, [AtLeast 2, AtMost 3])
+                                        -- Flaky; occasionally causes Z3 to blow up. Note that
+                                        -- this is most likely fixed in newer versions of Z3.
+                                        -- , ("intersperse1", 3000, [AtLeast 2, AtMost 3])
                                         , ("replicate1", 3000, [Exactly 2])
                                         , ("elemIndices1", 4000, [AtLeast 10])
                                         , ("minimum1", 3000, [AtLeast 1, AtMost 6]) -- Quantifier causes SMT failures

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -1223,7 +1223,7 @@ todoTests = testGroup "To Do"
 
 data ToDo = RunMain
           | RunToDo
-          deriving (Eq)
+          deriving Eq
 
 
 instance IsOption ToDo where

--- a/tests/TestFiles/InstTypes1.hs
+++ b/tests/TestFiles/InstTypes1.hs
@@ -58,38 +58,38 @@ myZip [] _ = []
 myZip _ [] = []
 myZip (x : xs) (y : ys) = (x,y) : myZip xs ys
 
-myMap :: [a] -> (a -> b) -> [b]
-myMap a f = map f a 
+-- myMap :: [a] -> (a -> b) -> [b]
+-- myMap a f = map f a
 
-myId :: a -> a
-myId x = x
+-- myId :: a -> a
+-- myId x = x
 
-takeOne :: a -> a -> a -> b -> a 
-takeOne x _ _ _ = x
+-- takeOne :: a -> a -> a -> b -> a
+-- takeOne x _ _ _ = x
 
-takeb :: a -> a -> a -> b -> b
-takeb _ _ _ x = x
+-- takeb :: a -> a -> a -> b -> b
+-- takeb _ _ _ x = x
 
-takeTwo :: a -> a -> a -> b -> a 
-takeTwo _ x _ _ = x
+-- takeTwo :: a -> a -> a -> b -> a
+-- takeTwo _ x _ _ = x
 
-takeTwo2 :: a -> a -> a -> b -> c -> c 
-takeTwo2 _ _ _ _ x = x
+-- takeTwo2 :: a -> a -> a -> b -> c -> c
+-- takeTwo2 _ _ _ _ x = x
 
-takeIntMul :: a -> a -> a -> b -> b
-takeIntMul _ _ _ x = x
+-- takeIntMul :: a -> a -> a -> b -> b
+-- takeIntMul _ _ _ x = x
 
-takeMul :: Int -> a -> a -> b -> Int
-takeMul x _ _ _ = x
+-- takeMul :: Int -> a -> a -> b -> Int
+-- takeMul x _ _ _ = x
 
-takeInt :: Int -> a -> b -> Int
-takeInt x _ _ = x
+-- takeInt :: Int -> a -> b -> Int
+-- takeInt x _ _ = x
 
-takeIntTwo :: Int -> a -> Int
-takeIntTwo x _ = x
+-- takeIntTwo :: Int -> a -> Int
+-- takeIntTwo x _ = x
 
-checkeq :: Eq a => a -> a -> Bool
-checkeq a a1 = a == a1
+-- checkeq :: Eq a => a -> a -> Bool
+-- checkeq a a1 = a == a1
 
 idlr :: Either l r -> Either l r 
 idlr x = x
@@ -105,8 +105,9 @@ extractRight (Left _) = Nothing
 take2 :: Either l r -> Either l r -> Either l r -> Either l r -> Either l r 
 take2 _ _ _ x = x
 
-takeMaybe :: a -> Maybe a 
-takeMaybe x = Just x 
+-- takeMaybe :: a -> Maybe a
+-- takeMaybe x = Just x
+-- takeMaybe _ = Nothing
 
 -- type that have no type variable 
 data Color = Red | Green | Blue | Yellow 
@@ -150,14 +151,14 @@ takeMyList x _ _ _ = x
 takeMyList2 :: MyList a -> MyList a -> MyList a -> MyList b -> MyList b
 takeMyList2 _ _ _ x = x 
 
-myListInt :: MyList Int -> MyList Int 
-myListInt x = x
+-- myListInt :: MyList Int -> MyList Int
+-- myListInt x = x
 
-myListTuple ::  MyList a -> MyList a -> (MyList a, MyList a)
-myListTuple x y = (x, y)
+-- myListTuple ::  MyList a -> MyList a -> (MyList a, MyList a)
+-- myListTuple x y = (x, y)
 
-myListTuple2 ::  MyList a -> MyList b -> (MyList b, MyList a)
-myListTuple2 x y = (y, x)
+-- myListTuple2 ::  MyList a -> MyList b -> (MyList b, MyList a)
+-- myListTuple2 x y = (y, x)
 
 myListMap :: [MyList a] -> (MyList a -> MyList b) -> [MyList b]
 myListMap a f = map f a 
@@ -185,8 +186,8 @@ triId x = x
 triFun :: Tri Int b c -> Tri b b c
 triFun (Tri x y z) = Tri y y z
 
-triInt :: Tri Int b c -> Int
-triInt (Tri x y z) = x 
+-- triInt :: Tri Int b c -> Int
+-- triInt (Tri x y z) = x
 
 triFuna :: Tri a b c -> a 
 triFuna (Tri x y z) = x
@@ -206,19 +207,19 @@ takeTri2 _ _ _ x = x
 -- test cases for type that take more than three type variable 
 -- data Fou a b c d where
 --   Fou :: a -> b -> Maybe c -> Maybe d -> Fou a b c d 
-data Fou a b c d = Fou a b (Maybe c) (Maybe d)
+-- data Fou a b c d = Fou a b (Maybe c) (Maybe d)
 
-instance (Eq a, Eq b, Eq c, Eq d) => Eq (Fou a b c d) where
-  (Fou a1 b1 c1 d1) == (Fou a2 b2 c2 d2) = a1 == a2 && b1 == b2 && c1 == c2 && d1 == d2
+-- instance (Eq a, Eq b, Eq c, Eq d) => Eq (Fou a b c d) where
+--   (Fou a1 b1 c1 d1) == (Fou a2 b2 c2 d2) = a1 == a2 && b1 == b2 && c1 == c2 && d1 == d2
 
-take4 :: Fou a b c d -> Fou a b c d -> Fou a b c d -> Fou a b c d -> Fou a b c d 
-take4 x _ _ _ = x
+-- take4 :: Fou a b c d -> Fou a b c d -> Fou a b c d -> Fou a b c d -> Fou a b c d
+-- take4 x _ _ _ = x
 
-take42 :: Fou b b c d -> Fou a b c d -> Fou a b c d -> Fou a b c d -> Fou b b c d 
-take42 x _ _ _ = x
+-- take42 :: Fou b b c d -> Fou a b c d -> Fou a b c d -> Fou a b c d -> Fou b b c d
+-- take42 x _ _ _ = x
 
-take4d :: Fou a b c d -> Maybe d 
-take4d (Fou x y z w) = w 
+-- take4d :: Fou a b c d -> Maybe d
+-- take4d (Fou x y z w) = w
 
-take4c :: Fou a b c d -> Maybe c
-take4c (Fou x y z w) = z
+-- take4c :: Fou a b c d -> Maybe c
+-- take4c (Fou x y z w) = z

--- a/tests/TestFiles/InstTypes1.hs
+++ b/tests/TestFiles/InstTypes1.hs
@@ -107,7 +107,6 @@ take2 _ _ _ x = x
 
 takeMaybe :: a -> Maybe a 
 takeMaybe x = Just x 
-takeMaybe _ = Nothing   
 
 -- type that have no type variable 
 data Color = Red | Green | Blue | Yellow 

--- a/tests/TestFiles/ListCallStack.hs
+++ b/tests/TestFiles/ListCallStack.hs
@@ -1,3 +1,6 @@
+{-# OPTIONS_GHC -Wno-x-partial #-}
+{-# OPTIONS_GHC -Wno-unrecognised-warning-flags #-}
+
 module ListCallStack where
 
 headOf :: [Int] -> Int

--- a/tests/TestFiles/Seq/Seq1.hs
+++ b/tests/TestFiles/Seq/Seq1.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP, MultiWayIf #-}
 {-# OPTIONS_GHC -Wno-x-partial #-}
+{-# OPTIONS_GHC -Wno-unrecognised-warning-flags #-}
 
 module Seq1 where
 

--- a/tests/TestFiles/Strings/StringCrash.hs
+++ b/tests/TestFiles/Strings/StringCrash.hs
@@ -1,3 +1,6 @@
+{-# OPTIONS_GHC -Wno-x-partial #-}
+{-# OPTIONS_GHC -Wno-unrecognised-warning-flags #-}
+
 module StringCrash where
 
 import Data.Char

--- a/tests/TestFiles/Strings/Strings1.hs
+++ b/tests/TestFiles/Strings/Strings1.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -Wno-x-partial #-}
+{-# OPTIONS_GHC -Wno-unrecognised-warning-flags #-}
 
 module Strings1 where
 

--- a/tests/TestUtils.hs
+++ b/tests/TestUtils.hs
@@ -32,19 +32,16 @@ mkConfigTestWithSetIO = mkConfigTestWithMapIO
 mkConfigTestWithMapIO :: IO Config
 mkConfigTestWithMapIO = do
     config <- mkConfigTestIO
-    homedir <- getHomeDirectory
     return $ config { base = base config }
 
 mkConfigTestWithSMTStringsIO :: IO Config
 mkConfigTestWithSMTStringsIO = do
     config <- mkConfigTestIO
-    homedir <- getHomeDirectory
     return $ config { smt_strings = UseSMTStrings, smt = ConCVC5 }
 
 mkConfigTestWithQuantifiedSMTStringsIO :: IO Config
 mkConfigTestWithQuantifiedSMTStringsIO = do
     config <- mkConfigTestIO
-    homedir <- getHomeDirectory
     return $ config { smt_strings = UseSMTStrings
                     , quantified_smt_strings = UseQuantifiers
                     , smt_discard_on_unknown = DiscardUnknown }
@@ -52,7 +49,6 @@ mkConfigTestWithQuantifiedSMTStringsIO = do
 mkConfigTestWithLambdaSMTStringsIO :: IO Config
 mkConfigTestWithLambdaSMTStringsIO = do
     config <- mkConfigTestIO
-    homedir <- getHomeDirectory
     return $ config { smt_strings = UseSMTStrings, using_smt_lams = UseSMTLams }
 
 mkConfigTestWithLitTablesSMTStringsIO :: IO Config

--- a/tests/UFMapTests.hs
+++ b/tests/UFMapTests.hs
@@ -1,3 +1,7 @@
+{-# OPTIONS_GHC -Wno-x-partial #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-unrecognised-warning-flags #-}
+
 module UFMapTests where
 
 import G2.Data.UFMap
@@ -149,19 +153,19 @@ prop_merge_preserves_values_simple :: Integer
                                    -> UFMap Integer Integer
                                    -> UFMap Integer Integer
                                    -> Property
-prop_merge_preserves_values_simple x (Fn2 f2) ufm1 ufm2 =
+prop_merge_preserves_values_simple x_ (Fn2 f2) ufm1 ufm2 =
     let
         m_ufm = mergeJoiningWithKey (\_ x y -> (x + y, [])) (\_ x -> (x, [])) f2 (+) (+) (+) ufm1 ufm2
     in
-    isJust (lookup x ufm1) || isJust (lookup x ufm2)
+    isJust (lookup x_ ufm1) || isJust (lookup x_ ufm2)
     ==>
-    property (isJust (lookup x m_ufm))
+    property (isJust (lookup x_ m_ufm))
 
 prop_merge_merges_values :: Integer
                          -> UFMap Integer (S.HashSet Integer)
                          -> UFMap Integer (S.HashSet Integer)
                          -> Property
-prop_merge_merges_values x ufm1 ufm2 = 
+prop_merge_merges_values x_ ufm1 ufm2 =
     let
         m_ufm = mergeJoiningWithKey (\_ x y -> (S.union x y, []))
                                     (\_ x -> (x, []))
@@ -170,16 +174,16 @@ prop_merge_merges_values x ufm1 ufm2 =
                                     S.union
                                     S.union
                                     ufm1 ufm2
-        s1 = case lookup x ufm1 of
+        s1 = case lookup x_ ufm1 of
                     Just s -> s
                     Nothing -> S.empty 
-        s2 = case lookup x ufm2 of
+        s2 = case lookup x_ ufm2 of
                     Just s -> s
                     Nothing -> S.empty
     in
     not (S.null s1) || not (S.null s2)
     ==>
-    property (s1 `isSubsetOf` (m_ufm ! x) && s2 `isSubsetOf` (m_ufm ! x))
+    property (s1 `isSubsetOf` (m_ufm ! x_) && s2 `isSubsetOf` (m_ufm ! x_))
 
 isSubsetOf :: (Eq a, Hashable a) => S.HashSet a -> S.HashSet a -> Bool
 isSubsetOf xs ys = all (\x -> x `S.member` ys) $ S.toList xs

--- a/tests_quasiquote/DeBruijn/Test.hs
+++ b/tests_quasiquote/DeBruijn/Test.hs
@@ -5,8 +5,6 @@ module DeBruijn.Test where
 import DeBruijn.Interpreter
 import G2.QuasiQuotes.QuasiQuotes
 
-import RegEx.RegEx as R
-
 solveDeBruijn :: [([Expr], Expr)] -> IO (Maybe Expr)
 solveDeBruijn =
     [g2| \(es :: [([Expr], Expr)]) -> ?(func :: Expr) |

--- a/tests_quasiquote/Evaluations.hs
+++ b/tests_quasiquote/Evaluations.hs
@@ -5,8 +5,6 @@ module Evaluations where
 import G2.QuasiQuotes.QuasiQuotes
 
 import DeBruijn.Interpreter as D
-import RegEx.RegEx as R
-
 
 -------------------------------------------
 -------------------------------------------

--- a/tests_quasiquote/Lambda/Interpreter.hs
+++ b/tests_quasiquote/Lambda/Interpreter.hs
@@ -5,8 +5,6 @@
 module Lambda.Interpreter where
 
 import Data.Data
-import Data.List
-import G2.QuasiQuotes.QuasiQuotes
 import G2.QuasiQuotes.G2Rep
 
 type Id = String
@@ -28,11 +26,11 @@ $(derivingG2Rep ''Expr)
 type Env = [(Id, Expr)]
 
 eval :: Env -> Expr -> Expr
-eval env (Var id) =
-  case lookup id env of
+eval env (Var id_) =
+  case lookup id_ env of
     Just expr -> eval env expr
-    Nothing -> Const (Fun id)
+    Nothing -> Const (Fun id_)
 eval env (App (Lam i body) arg) =
   eval ((i, arg) : env) body
-eval env expr = expr
+eval _ expr = expr
 

--- a/tests_quasiquote/Main.hs
+++ b/tests_quasiquote/Main.hs
@@ -8,15 +8,12 @@ import Test.Tasty.HUnit
 import DeBruijn.Test
 import Arithmetics.Interpreter
 import Arithmetics.Test
-import Lambda.Test
 import NQueens.Test
 import RegEx.Test
 import RegEx.RegEx
 import Simple.SimpleTest1
 
 import G2.Interface
-
-import qualified Evaluations as E
 
 tests :: TestTree
 tests = testGroup "All Tests"

--- a/tests_quasiquote/NQueens/Encoding.hs
+++ b/tests_quasiquote/NQueens/Encoding.hs
@@ -1,5 +1,5 @@
-{-# OPTIONS_GHC -Wno-x-partial #-}}
-{-# OPTIONS_GHC -Wno-unrecognised-warning-flags #-}}
+{-# OPTIONS_GHC -Wno-x-partial #-}
+{-# OPTIONS_GHC -Wno-unrecognised-warning-flags #-}
 
 module NQueens.Encoding where
 

--- a/tests_quasiquote/NQueens/Encoding.hs
+++ b/tests_quasiquote/NQueens/Encoding.hs
@@ -1,6 +1,7 @@
-module NQueens.Encoding where
+{-# OPTIONS_GHC -Wno-x-partial #-}}
+{-# OPTIONS_GHC -Wno-unrecognised-warning-flags #-}}
 
-import Data.List
+module NQueens.Encoding where
 
 type Queen = Int
 

--- a/tests_quasiquote/Simple/Simple1.hs
+++ b/tests_quasiquote/Simple/Simple1.hs
@@ -23,6 +23,7 @@ eval :: Stack -> Expr -> Expr
 eval (e:stck) (Lam e') = eval stck (rep e e')
 eval stck (App e1 e2) = eval (e2:stck) e1
 eval stck e@(Var _) = foldl1 App (e:stck)
+eval _ _ = error "empty stack and lambda, impossible"
 
 rep :: Expr -> Expr -> Expr
 rep e (Var _) = e

--- a/tests_quasiquote/Simple/SimpleTest1.hs
+++ b/tests_quasiquote/Simple/SimpleTest1.hs
@@ -5,8 +5,6 @@ module Simple.SimpleTest1 where
 import Simple.Simple1
 import G2.QuasiQuotes.QuasiQuotes
 
-import RegEx.RegEx as R
-
 sd :: () -> IO (Maybe Expr)
 sd =
     [g2| \(e :: ()) -> ?(func :: Expr) | eval [] (App func num1) == num1 |]


### PR DESCRIPTION
- Fixed regex for imports in state validation (missing support for `;`, which can serve as a newline)
- Mostly silenced some warnings that don't really matter in tests, like the partial function warning in functions we run G2 on
- Commented out quantified intersperse1 test that occasionally fails, for now