### PR TITLE
find, findIndex, and findIndices implemented with literal tables

### DIFF
--- a/base_setup.sh
+++ b/base_setup.sh
@@ -1,4 +1,4 @@
-base_commit=0ff83d0
+base_commit=aa7301f
 stubs_commit=4ff1c36
 
 get_base() {

--- a/base_setup.sh
+++ b/base_setup.sh
@@ -1,4 +1,4 @@
-base_commit=ad128e8
+base_commit=0ff83d0
 stubs_commit=4ff1c36
 
 get_base() {

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -666,7 +666,7 @@ testFileTests = testGroup "TestFiles"
                                         , ("takeWhile1", 20000, [Exactly 5])
                                         , ("find1", 20000, [Exactly 3])
                                         , ("findIndex1", 20000, [Exactly 3])
-                                        , ("findIndices1", 20000, [Exactly 6])
+                                        , ("findIndices1", 20000, [AtLeast 6, AtMost 7])
                                         ]
 
     , checkExpr "tests/TestFiles/Strings/Strings1.hs" 1000 "exclaimEq"

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -636,6 +636,9 @@ testFileTests = testGroup "TestFiles"
                                                               , ("map1", 5000, [AtLeast 5])
                                                               , ("dropWhile1", 1000, [AtLeast 5])
                                                               , ("takeWhile1", 1000, [AtLeast 5])
+                                                              , ("find1", 1000, [AtLeast 5])
+                                                              , ("findIndex1", 1000, [AtLeast 5])
+                                                              , ("findIndices1", 1000, [AtLeast 5])
 
                                                               ]
 
@@ -661,6 +664,9 @@ testFileTests = testGroup "TestFiles"
                                         , ("map1", 20000, [Exactly 8])
                                         , ("dropWhile1", 20000, [Exactly 6])
                                         , ("takeWhile1", 20000, [Exactly 5])
+                                        , ("find1", 20000, [Exactly 3])
+                                        , ("findIndex1", 20000, [Exactly 3])
+                                        , ("findIndices1", 20000, [Exactly 6])
                                         ]
 
     , checkExpr "tests/TestFiles/Strings/Strings1.hs" 1000 "exclaimEq"

--- a/tests/TestFiles/Seq/Seq1.hs
+++ b/tests/TestFiles/Seq/Seq1.hs
@@ -3,8 +3,9 @@
 
 module Seq1 where
 
-import Data.List
+import Data.List hiding (find)
 import qualified GHC.List as L
+import GHC.OldList (find)
 
 -- Validation
 floatEq :: (Eq a, RealFloat a) => a -> a -> Bool
@@ -405,3 +406,8 @@ takeWhile1 xs = case takeWhile (== 4) xs of
                     [4, 4] -> "Reasonable amount of fours. I'm satisfied."
                     [4] -> "Only one four? I'm disappointed."
                     _ -> "Either you gave me way too many fours, or none at all. How could you do this?"
+
+find1 :: [Int] -> Char
+find1 xs = case find (== 4) xs of
+                Just x -> if length xs > 2 then 'a' else 'b'
+                Nothing -> 'c'

--- a/tests/TestFiles/Seq/Seq1.hs
+++ b/tests/TestFiles/Seq/Seq1.hs
@@ -411,3 +411,15 @@ find1 :: [Int] -> Char
 find1 xs = case find (== 4) xs of
                 Just x -> if length xs > 2 then 'a' else 'b'
                 Nothing -> 'c'
+
+findIndex1 :: [Int] -> Char
+findIndex1 xs = case findIndex (\x -> x + 2 == 4) xs of
+                    Just i -> if i > 2 then 'a' else 'b'
+                    Nothing -> 'c'
+
+findIndices1 :: [Int] -> Double
+findIndices1 xs = case findIndices (\x -> x * 2 == 10) xs of
+                      [1, 2, 3] -> 0.0
+                      [] -> 1.1
+                      [2] -> 2.2
+                      _ -> 3.3


### PR DESCRIPTION
- Fixed bug with `find` being imported from Data.OldList instead of Data.Foldable (created crashes, even without literal tables enabled)
- Base PR: https://github.com/BillHallahan/base-4.9.1.0/pull/55