### PR TITLE
Refactor literal table errors

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -15,5 +15,6 @@ pkgs.mkShell {
   shellHook = ''
     bash base_setup.sh
     cabal update
+    cabal configure --enable-tests
   '';
 }

--- a/src/G2/Execution/LiteralTable.hs
+++ b/src/G2/Execution/LiteralTable.hs
@@ -25,9 +25,10 @@ import qualified Data.HashSet as HS
 import qualified Data.List as L
 import Data.Maybe
 
-introduceLitTable :: State t -> Name -> Id -> State t
-introduceLitTable s n i = s { lit_table_stack = lts
-                                  , exec_stack = es }
+introduceLitTable :: State t -> Name -> Id -> Type -> State t
+introduceLitTable s n i t = s { lit_table_stack = lts
+                              , exec_stack = es
+                              }
     where lts = S.push lt (lit_table_stack s)
           lt = LitTable { lt_arg = i
                         , lt_rec_funs = HS.empty
@@ -35,6 +36,7 @@ introduceLitTable s n i = s { lit_table_stack = lts
                         , lt_errored = False
                         , lt_init_pcs = path_conds s
                         , lt_partial = False
+                        , lt_ret_ty = t
                         }
           es = S.push (LitTableFrame (StartedBuilding n) True) (exec_stack s)
 
@@ -93,12 +95,13 @@ getBoolOptFromDC kv dcon
     | otherwise = Nothing
 
 -- The identity function represented as a `Lam`
-mkIdLam :: State t -> NameGen -> LitTable -> (Expr, EESymDiff, NameGen)
+mkIdLam :: State t -> NameGen -> LitTable -> Maybe (Expr, EESymDiff, NameGen)
 mkIdLam s ng lt =
     let tvnv = tyvar_env s
         kv = known_values s
         tenv = type_env s
         arg_ty = typeOf tvnv $ lt_arg lt
+        ret_ty = lt_ret_ty lt
         (arg_id, ng1) = freshId arg_ty ng
         lam_e = Lam TermL arg_id (Var arg_id)
         tup_e = mkTup4 kv tenv tvnv
@@ -106,25 +109,24 @@ mkIdLam s ng lt =
                     (mkTrue kv)
                     (Prim UnspecifiedOutput TyUnknown)
                     (mkFalse kv)
-    in (tup_e, [arg_id], ng1)
+    in if arg_ty == ret_ty then Just (tup_e, [arg_id], ng1) else Nothing
 
 -- Return Id for argument, and the Name that we're replacing in path conds
-mkLamArg :: State t -> NameGen -> LitTable -> (Id, Name, NameGen)
-mkLamArg s ng lt =
+mkLamArg :: State t -> NameGen -> LitTable -> Maybe (Id, Name, NameGen)
+mkLamArg s ng lt = do
     let eenv = expr_env s
-        tvnv = tyvar_env s
+    let tvnv = tyvar_env s
 
-        (Id lt_arg_name _) = lt_arg lt
-        lt_arg_e = fromJust $ E.deepLookup lt_arg_name eenv
-        (unboxed_sym, unboxed_name) =
-            case lt_arg_e of
-                App _ (v@(Var i)) -> (v, idName i)
-                _ -> error $ "lit table arg not in form (data_con unboxed_sym): " ++ show lt_arg_e
+    let (Id lt_arg_name _) = lt_arg lt
+    lt_arg_e <- E.deepLookup lt_arg_name eenv
+    (unboxed_sym, unboxed_name) <-
+        case lt_arg_e of
+            App _ (v@(Var i)) -> Just (v, idName i)
+            _ -> Nothing
 
-        -- Not entirely sure if the element variable should be unboxed or not
-        lit_ty = typeOf tvnv unboxed_sym
-        (elem_var, ng1) = freshId lit_ty ng
-    in (elem_var, unboxed_name, ng1)
+    let lit_ty = typeOf tvnv unboxed_sym
+    let (elem_var, ng1) = freshId lit_ty ng
+    return (elem_var, unboxed_name, ng1)
 
 -- Make a fully applied primitive tuple with four elements
 mkTup4 :: KnownValues -> TypeEnv -> TyVarEnv -> Expr -> Expr -> Expr -> Expr -> Expr
@@ -145,20 +147,33 @@ mkTup kv tenv tv_env x y =
           , y
           ]
 
+-- (Model function, Success, Partial table function to use with `assume`, Is partial)
+mkUnsuccessfulRet :: KnownValues -> TypeEnv -> TyVarEnv -> Expr
+mkUnsuccessfulRet kv tenv tv_env =
+    mkTup4 kv tenv tv_env
+        (Prim UnspecifiedOutput TyUnknown)
+        (mkFalse kv)
+        (Prim UnspecifiedOutput TyUnknown)
+        (mkFalse kv)
+
 -- Convert the literal table to a lambda function, which is then returned
 -- For functions returning a boolean, we optimize the representation to be
 -- the disjunction of all True path conditions (using `Prim Or`).
 -- For other functions, we use `ite`.
 litTableToLam :: State t -> NameGen -> LitTable -> (Expr, EESymDiff, NameGen)
 litTableToLam s ng lt =
+    case litTableToLam' s ng lt of
+        Just x -> x
+        Nothing -> (mkUnsuccessfulRet kv tenv tv_env, [], ng)
+    where
+        kv = known_values s
+        tenv = type_env s
+        tv_env = tyvar_env s
+
+litTableToLam' :: State t -> NameGen -> LitTable -> Maybe (Expr, EESymDiff, NameGen)
+litTableToLam' s ng lt =
     if lt_errored lt then
-        -- (Model function, Success, Partial table function to use with `assume`, Is partial)
-        (mkTup4 kv tenv tv_env
-            (Prim UnspecifiedOutput TyUnknown)
-            (mkFalse kv)
-            (Prim UnspecifiedOutput TyUnknown)
-            (mkFalse kv)
-        , [], ng)
+        Just (mkUnsuccessfulRet kv tenv tv_env, [], ng)
     else
         case HM.toList $ lt_mapping lt of
             [] ->
@@ -172,29 +187,66 @@ litTableToLam s ng lt =
         tenv = type_env s
         tv_env = tyvar_env s
 
-litTableToLamBool :: State t -> NameGen -> LitTable -> (Expr, EESymDiff, NameGen)
-litTableToLamBool s ng lt =
+litTableToLamBool :: State t -> NameGen -> LitTable -> Maybe (Expr, EESymDiff, NameGen)
+litTableToLamBool s ng lt = do
     let kv = known_values s
-        tenv = type_env s
-        tv_env = tyvar_env s
-        (elem_var, unboxed_name, ng1) = mkLamArg s ng lt
+    let tenv = type_env s
+    let tv_env = tyvar_env s
+    (elem_var, unboxed_name, ng1) <- mkLamArg s ng lt
 
-        lt_lst = HM.toList $ lt_mapping lt
-        lt_trues = makeAllTrue kv lt_lst
+    let lt_lst = HM.toList $ lt_mapping lt
+    let lt_trues = makeAllTrue kv lt_lst
 
         -- At this point, we know the literal table is non-empty, since we are creating a lambda for
         -- a boolean-returning function
-        or_exp = mkDisjunction kv lt_trues
-        or_exp1 = replaceVar unboxed_name (Var elem_var) or_exp
-        fun_exp = Lam TermL elem_var or_exp1
-        (partial_check, is_partial) =
+    let or_exp = mkDisjunction kv lt_trues
+    let or_exp1 = replaceVar unboxed_name (Var elem_var) or_exp
+    let fun_exp = Lam TermL elem_var or_exp1
+    let (partial_check, is_partial) =
             createPartialHandler (replaceVar unboxed_name (Var elem_var) lt) kv elem_var
-        tup_exp = mkTup4 kv tenv tv_env
+    let tup_exp = mkTup4 kv tenv tv_env
                       fun_exp
                       (mkTrue kv)
                       partial_check
                       is_partial
-    in (tup_exp, [elem_var], ng1)
+    return (tup_exp, [elem_var], ng1)
+
+litTableToLamNonBool :: State t -> NameGen -> LitTable -> Maybe (Expr, EESymDiff, NameGen)
+litTableToLamNonBool s ng lt = do
+    (elem_var, unboxed_name, ng1) <- mkLamArg s ng lt
+    let kv = known_values s
+    let tv_env = tyvar_env s
+    let tenv = type_env s
+    let lt_lst = HM.toList $ lt_mapping lt
+    -- `Char`s are represented as one character `String`s here, so we
+    -- need to extract the first character.
+    let wrap e t = if t == tyChar kv
+                       then mkApp [Prim SeqNth TyUnknown, e, Lit $ LitInt 0]
+                       else e
+    -- At this point, we assume there are no `Error`s in the literal table. This
+    -- means we have a total function, and we can pick one option to be the default.
+    ite_exp <- case lt_lst of
+                    ((_ {- We ignore the PathConds for the default -}, def_e):rest) ->
+                        Just $ L.foldl'
+                                (\prev_exp (pcs, e) ->
+                                    mkApp [ Prim Ite TyUnknown
+                                          , (pcsToExprBool kv $ PC.toList pcs)
+                                          , (wrap e $ typeOf tv_env e)
+                                          , prev_exp ]
+                                )
+                                (wrap def_e $ typeOf tv_env def_e)
+                                (reverse rest)
+                    _ -> Nothing
+    let ite_exp1 = replaceVar unboxed_name (Var elem_var) ite_exp
+    let fun_exp = Lam TermL elem_var ite_exp1
+    let (partial_check, is_partial) =
+            createPartialHandler (replaceVar unboxed_name (Var elem_var) lt) kv elem_var
+    let tup_exp = mkTup4 kv tenv tv_env
+                      fun_exp
+                      (mkTrue kv)
+                      partial_check
+                      is_partial
+    return (tup_exp, [elem_var], ng1)
 
 mkDisjunction :: KnownValues -> [[PathCond]] -> Expr
 mkDisjunction kv conds =
@@ -222,43 +274,6 @@ pcToExprBool kv pc =
         AltCond lit var bool -> let eq_e = mkApp [Prim Eq (tripleBoolTy kv), Lit lit, var]
                                 in if bool then eq_e else mkApp [Prim Not (doubleBoolTy kv), eq_e]
         _ -> error $ "unhandled pc:\n" ++ show pc
-
-litTableToLamNonBool :: State t -> NameGen -> LitTable -> (Expr, EESymDiff, NameGen)
-litTableToLamNonBool s ng lt =
-    let (elem_var, unboxed_name, ng1) = mkLamArg s ng lt
-        kv = known_values s
-        tv_env = tyvar_env s
-        tenv = type_env s
-        lt_lst = HM.toList $ lt_mapping lt
-        -- `Char`s are represented as one character `String`s here, so we
-        -- need to extract the first character.
-        wrap e t = if t == tyChar kv
-                       then mkApp [Prim SeqNth TyUnknown, e, Lit $ LitInt 0]
-                       else e
-        -- At this point, we assume there are no `Error`s in the literal table. This
-        -- means we have a total function, and we can pick one option to be the default.
-        ite_exp = case lt_lst of
-                    ((_ {- We ignore the PathConds for the default -}, def_e):rest) ->
-                        L.foldl'
-                            (\prev_exp (pcs, e) ->
-                                mkApp [ Prim Ite TyUnknown
-                                      , (pcsToExprBool kv $ PC.toList pcs)
-                                      , (wrap e $ typeOf tv_env e)
-                                      , prev_exp ]
-                            )
-                            (wrap def_e $ typeOf tv_env def_e)
-                            (reverse rest)
-                    _ -> error "impossible, empty list despite checking in litTableToLam"
-        ite_exp1 = replaceVar unboxed_name (Var elem_var) ite_exp
-        fun_exp = Lam TermL elem_var ite_exp1
-        (partial_check, is_partial) =
-            createPartialHandler (replaceVar unboxed_name (Var elem_var) lt) kv elem_var
-        tup_exp = mkTup4 kv tenv tv_env
-                      fun_exp
-                      (mkTrue kv)
-                      partial_check
-                      is_partial
-    in (tup_exp, [elem_var], ng1)
 
 tripleBoolTy :: KnownValues -> Type
 tripleBoolTy kv = mkTyFun [tyBool kv, tyBool kv, tyBool kv]

--- a/src/G2/Execution/LiteralTable.hs
+++ b/src/G2/Execution/LiteralTable.hs
@@ -190,21 +190,21 @@ litTableToLam' s ng lt =
 litTableToLamBool :: State t -> NameGen -> LitTable -> Maybe (Expr, EESymDiff, NameGen)
 litTableToLamBool s ng lt = do
     let kv = known_values s
-    let tenv = type_env s
-    let tv_env = tyvar_env s
+        tenv = type_env s
+        tv_env = tyvar_env s
     (elem_var, unboxed_name, ng1) <- mkLamArg s ng lt
 
     let lt_lst = HM.toList $ lt_mapping lt
-    let lt_trues = makeAllTrue kv lt_lst
+        lt_trues = makeAllTrue kv lt_lst
 
         -- At this point, we know the literal table is non-empty, since we are creating a lambda for
         -- a boolean-returning function
-    let or_exp = mkDisjunction kv lt_trues
-    let or_exp1 = replaceVar unboxed_name (Var elem_var) or_exp
-    let fun_exp = Lam TermL elem_var or_exp1
-    let (partial_check, is_partial) =
+        or_exp = mkDisjunction kv lt_trues
+        or_exp1 = replaceVar unboxed_name (Var elem_var) or_exp
+        fun_exp = Lam TermL elem_var or_exp1
+        (partial_check, is_partial) =
             createPartialHandler (replaceVar unboxed_name (Var elem_var) lt) kv elem_var
-    let tup_exp = mkTup4 kv tenv tv_env
+        tup_exp = mkTup4 kv tenv tv_env
                       fun_exp
                       (mkTrue kv)
                       partial_check
@@ -215,12 +215,12 @@ litTableToLamNonBool :: State t -> NameGen -> LitTable -> Maybe (Expr, EESymDiff
 litTableToLamNonBool s ng lt = do
     (elem_var, unboxed_name, ng1) <- mkLamArg s ng lt
     let kv = known_values s
-    let tv_env = tyvar_env s
-    let tenv = type_env s
-    let lt_lst = HM.toList $ lt_mapping lt
+        tv_env = tyvar_env s
+        tenv = type_env s
+        lt_lst = HM.toList $ lt_mapping lt
     -- `Char`s are represented as one character `String`s here, so we
     -- need to extract the first character.
-    let wrap e t = if t == tyChar kv
+        wrap e t = if t == tyChar kv
                        then mkApp [Prim SeqNth TyUnknown, e, Lit $ LitInt 0]
                        else e
     -- At this point, we assume there are no `Error`s in the literal table. This
@@ -238,10 +238,10 @@ litTableToLamNonBool s ng lt = do
                                 (reverse rest)
                     _ -> Nothing
     let ite_exp1 = replaceVar unboxed_name (Var elem_var) ite_exp
-    let fun_exp = Lam TermL elem_var ite_exp1
-    let (partial_check, is_partial) =
+        fun_exp = Lam TermL elem_var ite_exp1
+        (partial_check, is_partial) =
             createPartialHandler (replaceVar unboxed_name (Var elem_var) lt) kv elem_var
-    let tup_exp = mkTup4 kv tenv tv_env
+        tup_exp = mkTup4 kv tenv tv_env
                       fun_exp
                       (mkTrue kv)
                       partial_check

--- a/src/G2/Execution/LiteralTable.hs
+++ b/src/G2/Execution/LiteralTable.hs
@@ -115,9 +115,9 @@ mkIdLam s ng lt =
 mkLamArg :: State t -> NameGen -> LitTable -> Maybe (Id, Name, NameGen)
 mkLamArg s ng lt = do
     let eenv = expr_env s
-    let tvnv = tyvar_env s
+        tvnv = tyvar_env s
 
-    let (Id lt_arg_name _) = lt_arg lt
+        (Id lt_arg_name _) = lt_arg lt
     lt_arg_e <- E.deepLookup lt_arg_name eenv
     (unboxed_sym, unboxed_name) <-
         case lt_arg_e of
@@ -125,7 +125,7 @@ mkLamArg s ng lt = do
             _ -> Nothing
 
     let lit_ty = typeOf tvnv unboxed_sym
-    let (elem_var, ng1) = freshId lit_ty ng
+        (elem_var, ng1) = freshId lit_ty ng
     return (elem_var, unboxed_name, ng1)
 
 -- Make a fully applied primitive tuple with four elements

--- a/src/G2/Execution/PrimitiveEval.hs
+++ b/src/G2/Execution/PrimitiveEval.hs
@@ -444,7 +444,7 @@ evalPrimWithState s ng (App (App (App (App (App (Prim WriteMutVar _) _) (Type t)
     Just (newPCEmpty s', ng')
 evalPrimWithState _ _ e | [Prim WriteMutVar _, _, _, _, _, _] <- unApp e = Nothing
 evalPrimWithState s ng (App (Prim BuildLitTable _) fun_e)
-    | (TyFun fst_t _snd_t) <- typeOf (tyvar_env s) fun_e =
+    | (TyFun fst_t snd_t) <- typeOf (tyvar_env s) fun_e =
     -- When starting to build a literal table, we need to insert a literal table frame,
     -- put an empty table on the literal table stack, and create a new symbolic var
     -- to evaluate the function with
@@ -454,7 +454,7 @@ evalPrimWithState s ng (App (Prim BuildLitTable _) fun_e)
         eenv1 = E.insertSymbolic arg_id $ expr_env s
 
         (lt_name, ng2) = freshName ng1
-        s1 = introduceLitTable s lt_name arg_id
+        s1 = introduceLitTable s lt_name arg_id snd_t
 
         s2 = s1 { curr_expr = ce1
                 , expr_env = eenv1 }

--- a/src/G2/Language/Support.hs
+++ b/src/G2/Language/Support.hs
@@ -648,6 +648,7 @@ data LitTable = LitTable { lt_arg :: Id
                          , lt_errored :: Bool -- | Whether an error was encountered during creation or not
                          , lt_init_pcs :: PathConds -- | Conds from the creation process shouldn't linger
                          , lt_partial :: Bool -- | Whether this is a partial table or not
+                         , lt_ret_ty :: Type -- | The return type of the function we're modeling
                          }
                 deriving (Show, Eq, Read, Generic, Data)
 
@@ -655,17 +656,23 @@ instance Hashable LitTable
 
 instance Named LitTable where
     names (LitTable { lt_arg = lta, lt_mapping = ltm, lt_init_pcs = lip }) = names lta <> names ltm <> names lip
-    rename old new lt@(LitTable { lt_arg = lta, lt_rec_funs = ltf, lt_mapping = ltm, lt_init_pcs = lip }) =
+    rename old new lt@(LitTable { lt_arg = lta, lt_rec_funs = ltf
+                                , lt_mapping = ltm, lt_init_pcs = lip
+                                , lt_ret_ty = lrt }) =
         lt { lt_arg = rename old new lta
            , lt_rec_funs = rename old new ltf
            , lt_mapping = rename old new ltm
            , lt_init_pcs = rename old new lip
+           , lt_ret_ty = rename old new lrt
            }
-    renames hm lt@(LitTable { lt_arg = lta, lt_rec_funs = ltf, lt_mapping = ltm, lt_init_pcs = lip }) =
+    renames hm lt@(LitTable { lt_arg = lta, lt_rec_funs = ltf
+                            , lt_mapping = ltm, lt_init_pcs = lip
+                            , lt_ret_ty = lrt }) =
         lt { lt_arg = renames hm lta
            , lt_rec_funs = renames hm ltf
            , lt_mapping = renames hm ltm
            , lt_init_pcs = renames hm lip
+           , lt_ret_ty = renames hm lrt
            }
 
 instance Named LitTableCond where
@@ -721,21 +728,27 @@ instance Named StateDiff where
 instance ASTContainer LitTable Type where
     containedASTs (LitTable { lt_arg = lta, lt_rec_funs = ltf, lt_mapping = ltm, lt_init_pcs = lip }) =
         containedASTs lta <> containedASTs ltf <> containedASTs ltm <> containedASTs lip
-    modifyContainedASTs f lt@(LitTable { lt_arg = lta, lt_rec_funs = ltf, lt_mapping = ltm, lt_init_pcs = lip }) =
+    modifyContainedASTs f lt@(LitTable { lt_arg = lta, lt_rec_funs = ltf
+                                       , lt_mapping = ltm, lt_init_pcs = lip
+                                       , lt_ret_ty = lrt }) =
         lt { lt_arg = modifyContainedASTs f lta
            , lt_rec_funs = modifyContainedASTs f ltf
            , lt_mapping = modifyContainedASTs f ltm
            , lt_init_pcs = modifyContainedASTs f lip
+           , lt_ret_ty = modifyContainedASTs f lrt
            }
 
 instance ASTContainer LitTable Expr where
     containedASTs (LitTable { lt_arg = lta, lt_rec_funs = ltf, lt_mapping = ltm, lt_init_pcs = lip }) =
         containedASTs lta <> containedASTs ltf <> containedASTs ltm <> containedASTs lip
-    modifyContainedASTs f lt@(LitTable { lt_arg = lta, lt_rec_funs = ltf, lt_mapping = ltm, lt_init_pcs = lip }) =
+    modifyContainedASTs f lt@(LitTable { lt_arg = lta, lt_rec_funs = ltf
+                                       , lt_mapping = ltm, lt_init_pcs = lip
+                                       , lt_ret_ty = lrt }) =
         lt { lt_arg = modifyContainedASTs f lta
            , lt_rec_funs = modifyContainedASTs f ltf
            , lt_mapping = modifyContainedASTs f ltm
            , lt_init_pcs = modifyContainedASTs f lip
+           , lt_ret_ty = modifyContainedASTs f lrt
            }
 
 instance ASTContainer LitTableCond Type where

--- a/src/G2/Lib/Printers.hs
+++ b/src/G2/Lib/Printers.hs
@@ -852,7 +852,8 @@ prettyStateDiff pg (SD { new_conc_entries = nce
 
 prettyLitTable :: PrettyGuide -> LitTable -> T.Text
 prettyLitTable pg (LitTable { lt_arg = lta, lt_rec_funs = ltf, lt_mapping = ltm
-                            , lt_errored = lte, lt_init_pcs = lip, lt_partial = ltp })
+                            , lt_errored = lte, lt_init_pcs = lip, lt_partial = ltp
+                            , lt_ret_ty = lrt })
     | HM.null ltm = header <> "empty literal table"
     | otherwise =
         header <> (T.intercalate "\n----------------\n"
@@ -864,10 +865,11 @@ prettyLitTable pg (LitTable { lt_arg = lta, lt_rec_funs = ltf, lt_mapping = ltm
         fun_exps = map (mkDirtyExprHaskell pg) $ HS.toList ltf
         header = "-- start lit table --\n"
                      <> "symbolic id: " <> sym_id <> "\n"
+                     <> "function return type: " <> mkTypeHaskellPG pg lrt <> "\n"
                      <> "evaluated recursive function expr set:\n" <> (T.pack $ show fun_exps) <> "\n"
                      <> "error found: " <> (T.pack $ show lte) <> "\n"
                      <> "partial table: " <> (T.pack $ show ltp) <> "\n"
-                     <> "initial path conds:" <> prettyPathConds pg lip <> "\n"
+                     <> "initial path conds: " <> prettyPathConds pg lip <> "\n"
                      <> "mapping:\n"
 
 prettyLitTables :: PrettyGuide -> HM.HashMap Name LitTable -> T.Text

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -661,6 +661,7 @@ testFileTests = testGroup "TestFiles"
                                         [ ("any1", 20000, [Exactly 2])
                                         , ("all1", 20000, [Exactly 2])
                                         , ("all2", 1000, [AtLeast 20])
+                                        , ("all3", 3000, [AtLeast 0])
                                         , ("filter1", 20000, [Exactly 6])
                                         , ("map1", 20000, [Exactly 8])
                                         , ("dropWhile1", 20000, [Exactly 6])

--- a/tests/TestFiles/Seq/Seq1.hs
+++ b/tests/TestFiles/Seq/Seq1.hs
@@ -413,6 +413,11 @@ find1 xs = case find (== 4) xs of
                 Just x -> if length xs > 2 then 'a' else 'b'
                 Nothing -> 'c'
 
+find2 :: (Int -> Bool) -> [Int] -> Char
+find2 f xs = case find f xs of
+                 Just _ -> 'a'
+                 Nothing -> 'b'
+
 findIndex1 :: [Int] -> Char
 findIndex1 xs = case findIndex (\x -> x + 2 == 4) xs of
                     Just i -> if i > 2 then 'a' else 'b'
@@ -424,3 +429,6 @@ findIndices1 xs = case findIndices (\x -> x * 2 == 10) xs of
                       [] -> 1.1
                       [2] -> 2.2
                       _ -> 3.3
+
+findIndices2 :: [Double] -> [Int]
+findIndices2 = findIndices (\x -> x + 3 > 45.67)

--- a/tests/TestFiles/Seq/Seq1.hs
+++ b/tests/TestFiles/Seq/Seq1.hs
@@ -377,6 +377,11 @@ all2 xs = case L.all recFun xs of
             | x == 50 = True
             | otherwise = False
 
+all3 :: (Int -> Bool) -> [Int] -> Char
+all3 f xs = case L.all f xs of
+                 True -> 'a'
+                 False -> 'b'
+
 any1 :: [Int] -> String
 any1 xs = case L.any (== 4) xs of
             True -> "Four found. Not good"
@@ -413,11 +418,6 @@ find1 xs = case find (== 4) xs of
                 Just x -> if length xs > 2 then 'a' else 'b'
                 Nothing -> 'c'
 
-find2 :: (Int -> Bool) -> [Int] -> Char
-find2 f xs = case find f xs of
-                 Just _ -> 'a'
-                 Nothing -> 'b'
-
 findIndex1 :: [Int] -> Char
 findIndex1 xs = case findIndex (\x -> x + 2 == 4) xs of
                     Just i -> if i > 2 then 'a' else 'b'
@@ -429,6 +429,3 @@ findIndices1 xs = case findIndices (\x -> x * 2 == 10) xs of
                       [] -> 1.1
                       [2] -> 2.2
                       _ -> 3.3
-
-findIndices2 :: [Double] -> [Int]
-findIndices2 = findIndices (\x -> x + 3 > 45.67)


### PR DESCRIPTION
- Fix soundness issue with returning identity function
- Allow errors with literal table creation to return unsuccessful, instead of crashing. This manifests in trying to make a literal table from a symbolic function, and possibly other scenarios.