### PR TITLE
Lit table soundness fixes

### DIFF
--- a/src/G2/Execution/NewPC.hs
+++ b/src/G2/Execution/NewPC.hs
@@ -59,7 +59,7 @@ reduceNewPC _ _ _ ng NoState = return (ng, [])
 reduceNewPC _ _ _ ng (SingleState state) = return (ng, [state])
 reduceNewPC discard_unknown_states solver simplifier ng (SplitStatePieces state state_diffs)
     | inLitTableMode state
-    , scrut_bool || all (null . concretized) state_diffs = do
+    , scrut_bool || all (null . new_conc_entries) state_diffs = do
         res <- reduceToFirstDiff discard_unknown_states solver simplifier ng state state_diffs
         case res of
             Just (ng', first_s, pcs, other_diffs) ->
@@ -82,7 +82,8 @@ reduceNewPC discard_unknown_states solver simplifier ng (SplitStatePieces state 
 
         getCurrExpr (CurrExpr _ e) = e
 
-        wrap diff = LitTableFrame (Diff diff (path_conds state)) True
+        -- For booleans, we want to avoid concretization, only using the path conds
+        wrap diff = LitTableFrame (Diff (diff {new_conc_entries = []}) (path_conds state)) True
 
 -- Find the first diff to explore, when in literal table building mode
 reduceToFirstDiff :: (Solver solver, Simplifier simplifier)

--- a/src/G2/Execution/NewPC.hs
+++ b/src/G2/Execution/NewPC.hs
@@ -58,7 +58,7 @@ reduceNewPC :: (Solver solver, Simplifier simplifier)
 reduceNewPC _ _ _ ng NoState = return (ng, [])
 reduceNewPC _ _ _ ng (SingleState state) = return (ng, [state])
 reduceNewPC discard_unknown_states solver simplifier ng (SplitStatePieces state state_diffs)
-    | inLitTableMode state = do
+    | inLitTableMode state, scrut_bool = do
         res <- reduceToFirstDiff discard_unknown_states solver simplifier ng state state_diffs
         case res of
             Just (ng', first_s, pcs, other_diffs) ->
@@ -70,6 +70,17 @@ reduceNewPC discard_unknown_states solver simplifier ng (SplitStatePieces state 
     | otherwise =
         mapAccumMaybeM (\ng' sd -> reduceStateDiff discard_unknown_states solver simplifier ng' state sd) ng state_diffs
     where
+        kv = known_values state
+        tv_env = tyvar_env state
+        ce = curr_expr state
+        unwrapped_ce = getCurrExpr ce
+
+        scrut_bool = case unwrapped_ce of
+                      Case e _ _ _ -> typeOf tv_env e == tyBool kv
+                      _ -> False
+
+        getCurrExpr (CurrExpr _ e) = e
+
         wrap diff = LitTableFrame (
                         Diff diff (expr_env state, tyvar_env state, mutvar_env state, path_conds state)
                     ) True

--- a/src/G2/Execution/NewPC.hs
+++ b/src/G2/Execution/NewPC.hs
@@ -58,7 +58,8 @@ reduceNewPC :: (Solver solver, Simplifier simplifier)
 reduceNewPC _ _ _ ng NoState = return (ng, [])
 reduceNewPC _ _ _ ng (SingleState state) = return (ng, [state])
 reduceNewPC discard_unknown_states solver simplifier ng (SplitStatePieces state state_diffs)
-    | inLitTableMode state, scrut_bool = do
+    | inLitTableMode state
+    , scrut_bool || all (null . concretized) state_diffs = do
         res <- reduceToFirstDiff discard_unknown_states solver simplifier ng state state_diffs
         case res of
             Just (ng', first_s, pcs, other_diffs) ->
@@ -81,9 +82,7 @@ reduceNewPC discard_unknown_states solver simplifier ng (SplitStatePieces state 
 
         getCurrExpr (CurrExpr _ e) = e
 
-        wrap diff = LitTableFrame (
-                        Diff diff (expr_env state, tyvar_env state, mutvar_env state, path_conds state)
-                    ) True
+        wrap diff = LitTableFrame (Diff diff (path_conds state)) True
 
 -- Find the first diff to explore, when in literal table building mode
 reduceToFirstDiff :: (Solver solver, Simplifier simplifier)

--- a/src/G2/Execution/Rules.hs
+++ b/src/G2/Execution/Rules.hs
@@ -1932,8 +1932,8 @@ retLitTableFrame :: (Solver solver, Simplifier simplifier)
                  -> IO (Rule, [State t], NameGen)
 retLitTableFrame dus solver simplifier s ng ltc up stck = case ltc of
     Exploring _ -> retLTExploring ng updated_state sym_id
-    Diff sd (eenv, tvenv, mvenv, conds) ->
-        retLTDiff dus solver simplifier s ng sd eenv tvenv mvenv conds stck up
+    Diff sd conds ->
+        retLTDiff dus solver simplifier s ng sd conds stck up
     StartedBuilding n ->
         retLTStartedBuilding updated_state ng n
     where
@@ -1963,19 +1963,12 @@ retLTDiff :: (Solver solver, Simplifier simplifier)
           -> State t
           -> NameGen
           -> StateDiff
-          -> E.ExprEnv
-          -> TV.TyVarEnv
-          -> MutVarEnv
           -> PathConds
           -> S.Stack Frame
           -> LTUpdate
           -> IO (Rule, [State t], NameGen)
-retLTDiff dus solver simplifier s ng sd eenv tvenv mvenv conds stck up = do
-    -- We need to make sure the argument is still symbolic
-    -- after exploring other paths, since it can get concretized
-    let diff_state = s { exec_stack = stck, expr_env = eenv
-                        , tyvar_env = tvenv, mutvar_env = mvenv
-                        , path_conds = conds }
+retLTDiff dus solver simplifier s ng sd conds stck up = do
+    let diff_state = s { exec_stack = stck, path_conds = conds }
     res <- reduceStateDiff dus solver simplifier ng diff_state sd
     case res of
         -- This diff is unsat or unknown, try the next

--- a/src/G2/Interface/Interface.hs
+++ b/src/G2/Interface/Interface.hs
@@ -534,12 +534,15 @@ initSolver' avf config = do
 initSimplifier :: Config -> SomeSimplifier
 initSimplifier config =
     let
-        base_simp = SomeSimplifier $ FloatSimplifier :>> ArithSimplifier
-                 :>> BoolSimplifier :>> StringSimplifier :>> EqualitySimplifier :>> ConstSimplifier :>> LitConc
+        const_lit_simp = ConstSimplifier :>> LitConc
+        rest_simp = FloatSimplifier :>> ArithSimplifier
+                    :>> BoolSimplifier :>> StringSimplifier
+        base_simp = rest_simp :>> EqualitySimplifier :>> const_lit_simp
+        lam_simp = HigherOrderSimplifier :>> LamVarSimplifier :>> rest_simp :>> const_lit_simp
     in
     case using_smt_lams config of
-        UseSMTLams -> SomeSimplifier (HigherOrderSimplifier :>> LamVarSimplifier) .>> base_simp
-        NoSMTLams -> base_simp
+        UseSMTLams -> SomeSimplifier lam_simp
+        NoSMTLams -> SomeSimplifier base_simp
 
 mkTypeEnv :: HM.HashMap Name AlgDataTy -> TypeEnv
 mkTypeEnv = id

--- a/src/G2/Language/Support.hs
+++ b/src/G2/Language/Support.hs
@@ -633,10 +633,7 @@ instance ASTContainer Handle Type where
         h { h_start = modifyContainedASTs f s, h_pos = modifyContainedASTs f p }
 
 data LitTableCond = Exploring PathConds
-                  -- In the literal table process, we might modify some parts of
-                  -- the State that we don't want modified when we start Exploring
-                  -- other Diffs, so we need to save the original versions in Diff frames
-                  | Diff StateDiff (E.ExprEnv, TV.TyVarEnv, MutVarEnv, PathConds)
+                  | Diff StateDiff PathConds
                   | StartedBuilding Name
                   deriving (Show, Eq, Read, Generic, Data)
 

--- a/src/G2/Lib/Printers.hs
+++ b/src/G2/Lib/Printers.hs
@@ -821,7 +821,7 @@ prettyFrame pg (LitTableFrame ltc up) = header <> update_str <> ":\n" <> printLi
 printLiteralTableCond :: PrettyGuide -> LitTableCond -> T.Text
 printLiteralTableCond pg ltc
     | (Exploring pc) <- ltc = "exploring " <> prettyPathConds pg pc
-    | (Diff sd _) <- ltc = prettyStateDiff pg sd <> " note: truncated (expr_env, tyvar_env, mutvar_env, conds) for now"
+    | (Diff sd pc) <- ltc = prettyStateDiff pg sd <> "\nconds =\n" <> prettyPathConds pg pc
     | (StartedBuilding n) <- ltc = "started building " <> mkNameHaskell pg n
 
 prettyStateDiff :: PrettyGuide -> StateDiff -> T.Text

--- a/src/G2/Lib/Printers.hs
+++ b/src/G2/Lib/Printers.hs
@@ -821,7 +821,8 @@ prettyFrame pg (LitTableFrame ltc up) = header <> update_str <> ":\n" <> printLi
 printLiteralTableCond :: PrettyGuide -> LitTableCond -> T.Text
 printLiteralTableCond pg ltc
     | (Exploring pc) <- ltc = "exploring " <> prettyPathConds pg pc
-    | (Diff sd pc) <- ltc = prettyStateDiff pg sd <> "\nconds =\n" <> prettyPathConds pg pc
+    | (Diff sd pc) <- ltc = prettyStateDiff pg sd <> "\nold conds to put back:\n"
+                                <> prettyPathConds pg pc <> "---\n"
     | (StartedBuilding n) <- ltc = "started building " <> mkNameHaskell pg n
 
 prettyStateDiff :: PrettyGuide -> StateDiff -> T.Text
@@ -839,14 +840,14 @@ prettyStateDiff pg (SD { new_conc_entries = nce
         [ "--- state diff: "
         , "  concrete entries -> " <> T.intercalate ", " (map prettyConc nce)
         , "  symbolic entries -> " <> T.intercalate ", " (map (mkIdHaskell pg) nse)
-        , "  path conds -> " <> T.intercalate ", " (map (prettyPathCond pg) pc)
+        , "  new path conds -> " <> T.intercalate ", " (map (prettyPathCond pg) pc)
         , "  concretized -> " <> T.intercalate ", " (map (mkIdHaskell pg) concIds)
-        , "  true_assert -> " <> T.pack (show nta)
-        , "  assert_ids -> " <> maybe "Nothing" (printFuncCallPG pg) nai
-        , "  curr_expr -> " <> prettyCurrExpr pg n_curre
-        , "  new_conc_types -> " <> T.intercalate ", " (map prettyConcType nct)
-        , "  new_sym_types -> " <> T.intercalate ", " (map (mkIdHaskell pg) nst)
-        , "  new_mut_vars -> " <> T.intercalate ", " (map prettyMutVar nmv)
+        , "  true assert -> " <> T.pack (show nta)
+        , "  assert ids -> " <> maybe "Nothing" (printFuncCallPG pg) nai
+        , "  curr expr -> " <> prettyCurrExpr pg n_curre
+        , "  new conc types -> " <> T.intercalate ", " (map prettyConcType nct)
+        , "  new sym types -> " <> T.intercalate ", " (map (mkIdHaskell pg) nst)
+        , "  new mut vars -> " <> T.intercalate ", " (map prettyMutVar nmv)
         , "---"
         ]
     where

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -567,6 +567,7 @@ testFileTests = testGroup "TestFiles"
                                            , ("dropWhile1", 10000, [Exactly 4])
                                            , ("dropWhile2", 10000, [Exactly 1])
                                            , ("takeWhile1", 10000, [Exactly 4])
+                                           , ("takeWhile2", 10000, [Exactly 6])
                                            , ("map1", 10000, [AtLeast 3, AtMost 4])
                                            , ("map2", 10000, [AtLeast 4, AtMost 5])
                                            -- Functions that error

--- a/tests/TestFiles/Strings/Strings1.hs
+++ b/tests/TestFiles/Strings/Strings1.hs
@@ -696,6 +696,11 @@ takeWhile1 s = case takeWhile (/= '@') s of
                    "a" -> 1
                    _ -> 2
 
+takeWhile2 :: Maybe Int -> String -> Int
+takeWhile2 m s = case takeWhile (\x -> case m of Just _ -> True; Nothing -> False) s of
+                   "b" -> 0
+                   _ -> case m of Just _ -> 1; Nothing -> 2
+
 testQualImp :: String -> M.Maybe Char
 testQualImp s = case "12345" `isInfixOf` s of
                     True -> M.Nothing


### PR DESCRIPTION
- Removes extra expr env, ... copied around
- Branches on symbolic ADTs encountered in lit table mode
- EqualitySimplifier concretizes some literals, which causes errors without expr env copies