### PR TITLE
Fix for seq in lit tables

### DIFF
--- a/src/G2/Execution/LiteralTable.hs
+++ b/src/G2/Execution/LiteralTable.hs
@@ -72,6 +72,7 @@ stopUpdateLastExpl stck = case S.pop stck of
 makeAllTrue :: KnownValues -> [(PathConds, Expr)] -> [[PathCond]]
 makeAllTrue _ [] = []
 makeAllTrue kv ((pcs, e):xs) | Just True <- getBool kv e = (PC.toList pcs):makeAllTrue kv xs
+makeAllTrue kv ((_, e):xs)   | Just False <- getBool kv e = makeAllTrue kv xs
 makeAllTrue kv ((pcs, e):xs) =
     let lst = PC.toList pcs
         pc1 = ExtCond e True

--- a/src/G2/Execution/RuleTypes.hs
+++ b/src/G2/Execution/RuleTypes.hs
@@ -40,6 +40,7 @@ data Rule = RuleEvalVal
           | RuleEvalCaseNonVal
           | RuleEvalCaseBottom
           | RuleEvalCaseInCase
+          | RuleEvalCaseUpdates
 
           | RuleEvalCastSplit
           | RuleEvalCast

--- a/src/G2/Execution/Rules.hs
+++ b/src/G2/Execution/Rules.hs
@@ -513,7 +513,7 @@ evalCase s@(State { expr_env = eenv
   -- Hacky fix for `seq`. When we only have a default alt, and we have update
   -- frames below us, point them all to the default alt's expr.
   | inLitTableMode s
-  , alts <- [Alt Default branchexp]
+  , [Alt Default branchexp] <- alts
   , Just s1 <- popUpdateFrames branchexp s =
     ( RuleEvalCaseUpdates
     , newPCEmpty s1

--- a/src/G2/Execution/Rules.hs
+++ b/src/G2/Execution/Rules.hs
@@ -473,7 +473,7 @@ evalLet s@(State { expr_env = eenv })
                           , curr_expr = CurrExpr Evaluate e'}]
                      , ng')
 
--- | Pop and apply update frames until a case frame shows up
+-- | Pop and apply update frames until a case frame shows up.
 popToCaseFrame :: State t -> CurrExpr -> Maybe (State t, Id, Type, [Alt])
 popToCaseFrame s ce = case S.pop (exec_stack s) of
                         Just (UpdateFrame n, stck) ->
@@ -483,7 +483,18 @@ popToCaseFrame s ce = case S.pop (exec_stack s) of
                         _ -> Nothing
                       where unwrap (CurrExpr _ e) = e
 
--- | Create `[Alts]` for a case of case optimization
+-- | Pop all update frames, returning Nothing if there are none.
+popUpdateFrames :: Expr -> State t -> Maybe (State t)
+popUpdateFrames e s = case S.pop stck of
+                          Just (UpdateFrame n, stck') ->
+                              let s' = s { expr_env = E.insert n e eenv, exec_stack = stck' }
+                              in Just $ fromMaybe s' (popUpdateFrames e s')
+                          _ -> Nothing
+    where
+        eenv = expr_env s
+        stck = exec_stack s
+
+-- | Create `[Alts]` for a case of case optimization.
 caseOfCaseAlts :: Type -> [Alt] -> [Alt] -> Id -> [Alt]
 caseOfCaseAlts lower_t lower_alts higher_alts lower_bind = L.map makeAlt higher_alts
     where
@@ -498,6 +509,15 @@ evalCase s@(State { expr_env = eenv
                   , tyvar_env = tvnv
                   })
          (Bindings { name_gen = ng, data_con_pc_map = dcpm }) mexpr bind t alts
+
+  -- Hacky fix for `seq`. When we only have a default alt, and we have update
+  -- frames below us, point them all to the default alt's expr.
+  | inLitTableMode s
+  , alts <- [Alt Default branchexp]
+  , Just s1 <- popUpdateFrames branchexp s =
+    ( RuleEvalCaseUpdates
+    , newPCEmpty s1
+    , ng )
 
   -- Case of case optimization, always needed for literal table creation
   -- This pops the nested case frame off the stack, and creates a new


### PR DESCRIPTION
- Points update frames to the expr in the default case of a case statement in lit table mode, when possible