### PR TITLE
Regex primitives in plugin

### DIFF
--- a/.github/workflows/plugin.yaml
+++ b/.github/workflows/plugin.yaml
@@ -43,6 +43,9 @@ jobs:
       uses: cda-tum/setup-z3@v1
       with:
         version: 4.15.4
+    
+    - name: Install CVC5
+      run: sudo apt-get install cvc5
    
     - name: Getting custom base
       run: bash base_setup.sh

--- a/g2.cabal
+++ b/g2.cabal
@@ -435,7 +435,22 @@ executable Verify
   main-is:             Main.hs
 
 executable Verify-QuickCheck
-  other-modules:       ZenoBadProp
+  other-modules:         ZenoBadProp
+                       , ZenoWithDelete
+                       , ZenoWithDrop
+                       , ZenoWithElem
+                       , ZenoWithFilter
+                       , ZenoWithHeight
+                       , ZenoWithIns
+                       , ZenoWithLen
+                       , ZenoWithMap
+                       , ZenoWithMirror
+                       , ZenoWithRev
+                       , ZenoWithTake
+                       , ZenoWithTakeWhile
+                       , ZenoWithZip
+                       , Definitions
+                       , Nat
   -- other-extensions:
   build-depends:         base >= 4.8 && < 5
                        , containers

--- a/src/G2/Plugin.hs
+++ b/src/G2/Plugin.hs
@@ -29,6 +29,18 @@ module G2.Plugin (SymEx (..)
                  , smtFoldLeft
                 --  , smtFoldLeftI
 
+                , smtReRange
+                , smtInRe
+                , smtToRe
+                , smtReNone
+                , smtReAll
+                , smtReAllChar
+                , smtReUnion
+                , smtReConcat
+                , smtReInter
+                , smtReStar
+                , smtReComp
+
                 , genVal
 
                  , comp

--- a/src/G2/Plugin.hs
+++ b/src/G2/Plugin.hs
@@ -439,6 +439,18 @@ adjustFunctions nm ex_g2 = do
 
     . adjustFunction ("pIsSMTRep#", Just "G2.Plugin.Prim") nm (callPrim nm "isSMTRep#")
 
+    . adjustFunction ("pSmtReRange#", Just "G2.Plugin.Prim") nm (callPrim nm "reRange#")
+    . adjustFunction ("pSmtInRe#", Just "G2.Plugin.Prim") nm (callPrim nm "inRe#")
+    . adjustFunction ("pSmtToRe#", Just "G2.Plugin.Prim") nm (callPrim nm "toRe#")
+    . adjustFunction ("pSmtReNone#", Just "G2.Plugin.Prim") nm (callPrim nm "reNone#")
+    . adjustFunction ("pSmtReAll#", Just "G2.Plugin.Prim") nm (callPrim nm "reAll#")
+    . adjustFunction ("pSmtReAllChar#", Just "G2.Plugin.Prim") nm (callPrim nm "reAllChar#")
+    . adjustFunction ("pSmtReConcat#", Just "G2.Plugin.Prim") nm (callPrim nm "reConcat#")
+    . adjustFunction ("pSmtReUnion#", Just "G2.Plugin.Prim") nm (callPrim nm "reUnion#")
+    . adjustFunction ("pSmtReInter#", Just "G2.Plugin.Prim") nm (callPrim nm "reInter#")
+    . adjustFunction ("pSmtReComp#", Just "G2.Plugin.Prim") nm (callPrim nm "reComp#")
+    . adjustFunction ("pSmtReStar#", Just "G2.Plugin.Prim") nm (callPrim nm "reStar#")
+
     . adjustMkSymbolicPrim SNoLog "pSymGen#" (Just "G2.Plugin.Prim") nm
 
     . adjustFunction ("$&&#", Just "G2.Plugin.Prim") nm (callPrim nm "&&#")
@@ -530,6 +542,39 @@ smtFoldLeft' f x xs =
 -- smtFoldLeftI f (I# i) !x xs =
 --     let f' j = f (I# j) in
 --     xs `evalSeq` pSmtFoldLeftI# f' i x xs 
+
+smtReRange :: String -> String -> String
+smtReRange xs ys = xs `evalSeq` ys `evalSeq` pSmtReRange# xs ys
+
+smtInRe :: String -> String -> Bool
+smtInRe xs rl = xs `evalSeq` rl `evalSeq` pSmtInRe# xs rl
+
+smtToRe :: String -> String
+smtToRe xs = xs `evalSeq` pSmtToRe# xs
+
+smtReNone :: String
+smtReNone = pSmtReNone#
+
+smtReAll :: String
+smtReAll = pSmtReAll#
+
+smtReAllChar :: String
+smtReAllChar = pSmtReAllChar#
+
+smtReConcat :: String -> String -> String
+smtReConcat f s = f `evalSeq` s `evalSeq` pSmtReConcat# f s
+
+smtReUnion :: String -> String -> String
+smtReUnion f s = f `evalSeq` s `evalSeq` pSmtReUnion# f s
+
+smtReInter :: String -> String -> String
+smtReInter f s = f `evalSeq` s `evalSeq` pSmtReInter# f s
+
+smtReStar :: String -> String
+smtReStar r = r `evalSeq` pSmtReStar# r
+
+smtReComp :: String -> String
+smtReComp r = r `evalSeq` pSmtReComp# r
 
 genVal :: forall a . (a -> Bool) -> a
 genVal p = let !x = pSymGen# @a in assume (p x) x

--- a/src/G2/Plugin/Prim.hs
+++ b/src/G2/Plugin/Prim.hs
@@ -84,6 +84,50 @@ pSmtFoldLeft# = error "pSmtFoldLeft#"
 pSmtFoldLeftI# :: (Int# -> a -> b -> a) -> Int# -> a -> [b] -> a
 pSmtFoldLeftI# = error "pSmtFoldLeftI#"
 
+{-# NOINLINE pSmtReRange# #-}
+pSmtReRange# :: String -> String -> String
+pSmtReRange# = error "pSmtReRange#"
+
+{-# NOINLINE pSmtInRe# #-}
+pSmtInRe# :: String -> String -> Bool
+pSmtInRe# = error "pSmtInRe#"
+
+{-# NOINLINE pSmtToRe# #-}
+pSmtToRe# :: String -> String
+pSmtToRe# = error "pSmtToRe#"
+
+{-# NOINLINE pSmtReNone# #-}
+pSmtReNone# :: String
+pSmtReNone# = error "pSmtReNone#"
+
+{-# NOINLINE pSmtReAll# #-}
+pSmtReAll# :: String
+pSmtReAll# = error "pSmtReAll#"
+
+{-# NOINLINE pSmtReAllChar# #-}
+pSmtReAllChar# :: String
+pSmtReAllChar# = error "pSmtReAllChar#"
+
+{-# NOINLINE pSmtReConcat# #-}
+pSmtReConcat# :: String -> String -> String
+pSmtReConcat# = error "pSmtReConcat#"
+
+{-# NOINLINE pSmtReUnion# #-}
+pSmtReUnion# :: String -> String -> String
+pSmtReUnion# = error "pSmtReUnion#"
+
+{-# NOINLINE pSmtReInter# #-}
+pSmtReInter# :: String -> String -> String
+pSmtReInter# = error "pSmtReInter#"
+
+{-# NOINLINE pSmtReStar# #-}
+pSmtReStar# :: String -> String
+pSmtReStar# = error "pSmtReStar#"
+
+{-# NOINLINE pSmtReStar# #-}
+pSmtReComp# :: String -> String
+pSmtReComp# = error "pSmtReComp#"
+
 {-# NOINLINE pIsSMTRep# #-}
 pIsSMTRep# :: [a] -> Bool
 pIsSMTRep# _ = error "pIsSMTRep#"

--- a/src/G2/Plugin/Prim.hs
+++ b/src/G2/Plugin/Prim.hs
@@ -85,47 +85,47 @@ pSmtFoldLeftI# :: (Int# -> a -> b -> a) -> Int# -> a -> [b] -> a
 pSmtFoldLeftI# = error "pSmtFoldLeftI#"
 
 {-# NOINLINE pSmtReRange# #-}
-pSmtReRange# :: String -> String -> String
+pSmtReRange# :: [a] -> [a] -> [a]
 pSmtReRange# = error "pSmtReRange#"
 
 {-# NOINLINE pSmtInRe# #-}
-pSmtInRe# :: String -> String -> Bool
+pSmtInRe# :: [a] -> [a] -> Bool
 pSmtInRe# = error "pSmtInRe#"
 
 {-# NOINLINE pSmtToRe# #-}
-pSmtToRe# :: String -> String
+pSmtToRe# :: [a] -> [a]
 pSmtToRe# = error "pSmtToRe#"
 
 {-# NOINLINE pSmtReNone# #-}
-pSmtReNone# :: String
+pSmtReNone# :: [a]
 pSmtReNone# = error "pSmtReNone#"
 
 {-# NOINLINE pSmtReAll# #-}
-pSmtReAll# :: String
+pSmtReAll# :: [a]
 pSmtReAll# = error "pSmtReAll#"
 
 {-# NOINLINE pSmtReAllChar# #-}
-pSmtReAllChar# :: String
+pSmtReAllChar# :: [a]
 pSmtReAllChar# = error "pSmtReAllChar#"
 
 {-# NOINLINE pSmtReConcat# #-}
-pSmtReConcat# :: String -> String -> String
+pSmtReConcat# :: [a] -> [a] -> [a]
 pSmtReConcat# = error "pSmtReConcat#"
 
 {-# NOINLINE pSmtReUnion# #-}
-pSmtReUnion# :: String -> String -> String
+pSmtReUnion# :: [a] -> [a] -> [a]
 pSmtReUnion# = error "pSmtReUnion#"
 
 {-# NOINLINE pSmtReInter# #-}
-pSmtReInter# :: String -> String -> String
+pSmtReInter# :: [a] -> [a] -> [a]
 pSmtReInter# = error "pSmtReInter#"
 
 {-# NOINLINE pSmtReStar# #-}
-pSmtReStar# :: String -> String
+pSmtReStar# :: [a] -> [a]
 pSmtReStar# = error "pSmtReStar#"
 
 {-# NOINLINE pSmtReComp# #-}
-pSmtReComp# :: String -> String
+pSmtReComp# :: [a] -> [a]
 pSmtReComp# = error "pSmtReComp#"
 
 {-# NOINLINE pIsSMTRep# #-}

--- a/src/G2/Plugin/Prim.hs
+++ b/src/G2/Plugin/Prim.hs
@@ -124,7 +124,7 @@ pSmtReInter# = error "pSmtReInter#"
 pSmtReStar# :: String -> String
 pSmtReStar# = error "pSmtReStar#"
 
-{-# NOINLINE pSmtReStar# #-}
+{-# NOINLINE pSmtReComp# #-}
 pSmtReComp# :: String -> String
 pSmtReComp# = error "pSmtReComp#"
 

--- a/tests/G2Plugin/Strings/Strings.cabal
+++ b/tests/G2Plugin/Strings/Strings.cabal
@@ -20,6 +20,7 @@ library
     import:           warnings
     exposed-modules:    Strings
                       , Tuples
+                      , Regex
     -- other-modules:
     -- other-extensions:
     build-depends:    base >=4.14

--- a/tests/G2Plugin/Strings/src/Regex.hs
+++ b/tests/G2Plugin/Strings/src/Regex.hs
@@ -1,17 +1,93 @@
-{-# LANGUAGE BangPatterns #-}
-
 module Regex where
 
 import G2.Plugin
-import Data.Char (ord)
 
-{-# ANN isNum (SMTEquivIs "smtIsNum") #-}
+{-# ANN isNum (SMTEquivIsWithConfig "smtIsNum" "--smt cvc5")
+    #-}
 isNum :: String -> Bool
-isNum (num:rest) = ord num >= ord '0' && ord num <= ord '9' && isNum rest
+isNum (x:xs) = x >= '0' && x <= '9' && isNum xs
 isNum _ = True
 
 smtIsNum :: String -> Bool
 smtIsNum s =
-    let !digit = smtReRange "0" "9"
-        !many_digits = smtReStar digit
+    let digit = smtReRange "0" "9"
+        many_digits = smtReStar digit
     in smtInRe s many_digits
+
+{-# ANN isNumBad (SMTEquivIsWithConfig "smtIsNumBad" "--smt cvc5") 
+    #-}
+isNumBad :: String -> Bool
+isNumBad (x:xs) = x >= '0' && x <= '9' && isNumBad xs
+isNumBad _ = True
+
+smtIsNumBad :: String -> Bool
+smtIsNumBad s =
+    let digit = smtReRange "4" "5"
+        many_digits = smtReStar digit
+    in smtInRe s many_digits
+
+{-# ANN containsFour (SMTEquivIsWithConfig "smtContainsFour" "--smt cvc5")
+    #-}
+containsFour :: String -> Bool
+containsFour [] = False
+containsFour ('4':_) = True
+containsFour (_:xs) = containsFour xs
+
+smtContainsFour :: String -> Bool
+smtContainsFour s =
+    let four = smtToRe "4"
+        four_n = four `smtReUnion` smtReNone
+        any_chars = smtReStar smtReAllChar
+        has_four = any_chars `smtReConcat` four_n `smtReConcat` any_chars
+    in smtInRe s has_four
+
+{-# ANN containsFourBad (SMTEquivIsWithConfig "smtContainsFourBad" "--smt cvc5")
+    #-}
+containsFourBad :: String -> Bool
+containsFourBad [] = False
+containsFourBad ('4':_) = True
+containsFourBad (_:xs) = containsFourBad xs
+
+smtContainsFourBad :: String -> Bool
+smtContainsFourBad s =
+    let four = smtReComp smtReAll -- Definitely not a four
+        any_chars = smtReStar smtReAllChar
+        has_four = any_chars `smtReConcat` four `smtReConcat` any_chars
+    in smtInRe s has_four
+
+{-# ANN noPat (SMTEquivIsWithConfig "smtNoPat" "--smt cvc5 --print-smt")
+    #-}
+noPat :: String -> Bool
+noPat [] = True
+noPat ('6':_) = False
+noPat ('4':_) = False
+noPat (_:xs) = noPat xs
+
+smtNoPat :: String -> Bool
+smtNoPat s =
+    let pat1 = smtToRe "6"
+        pat2 = smtToRe "4"
+        all_pat = pat1 `smtReUnion` pat2
+        any_chars = smtReStar smtReAllChar
+        has_pat = any_chars `smtReConcat` all_pat `smtReConcat` any_chars
+        no_pat = smtReComp has_pat
+    in smtInRe s no_pat
+
+{-# ANN noPatBad (SMTEquivIsWithConfig "smtNoPatBad" "--smt cvc5")
+    #-}
+noPatBad :: String -> Bool
+noPatBad [] = True
+noPatBad ('6':_) = False
+noPatBad ('4':_) = False
+noPatBad (_:xs) = noPatBad xs
+
+smtNoPatBad :: String -> Bool
+smtNoPatBad s =
+    let pat1 = smtToRe "6"
+        pat2 = smtToRe "4"
+        -- Intersection instead of Union makes this impossible
+        all_pat = pat1 `smtReInter` pat2
+        any_chars = smtReStar smtReAllChar
+        has_pat = any_chars `smtReConcat` all_pat `smtReConcat` any_chars
+        no_pat = smtReComp has_pat
+    in smtInRe s no_pat

--- a/tests/G2Plugin/Strings/src/Regex.hs
+++ b/tests/G2Plugin/Strings/src/Regex.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE BangPatterns #-}
+
+module Regex where
+
+import G2.Plugin
+import Data.Char (ord)
+
+{-# ANN isNum (SMTEquivIs "smtIsNum") #-}
+isNum :: String -> Bool
+isNum (num:rest) = ord num >= ord '0' && ord num <= ord '9' && isNum rest
+isNum _ = True
+
+smtIsNum :: String -> Bool
+smtIsNum s =
+    let !digit = smtReRange "0" "9"
+        !many_digits = smtReStar digit
+    in smtInRe s many_digits

--- a/tests/G2Plugin/Strings/src/Regex.hs
+++ b/tests/G2Plugin/Strings/src/Regex.hs
@@ -5,7 +5,7 @@ module Regex where
 import G2.Plugin
 import Data.Char (ord)
 
-{-# ANN isNum (SMTEquivIs "smtIsNum") #-}
+{-# ANN isNum (SMTEquivIsWithConfig "smtIsNum" "--log-pretty a") #-}
 isNum :: String -> Bool
 isNum (num:rest) = ord num >= ord '0' && ord num <= ord '9' && isNum rest
 isNum _ = True

--- a/tests/G2Plugin/Strings/src/Regex.hs
+++ b/tests/G2Plugin/Strings/src/Regex.hs
@@ -5,7 +5,7 @@ module Regex where
 import G2.Plugin
 import Data.Char (ord)
 
-{-# ANN isNum (SMTEquivIsWithConfig "smtIsNum" "--log-pretty a") #-}
+{-# ANN isNum (SMTEquivIs "smtIsNum") #-}
 isNum :: String -> Bool
 isNum (num:rest) = ord num >= ord '0' && ord num <= ord '9' && isNum rest
 isNum _ = True

--- a/tests_plugin/Main.hs
+++ b/tests_plugin/Main.hs
@@ -56,6 +56,9 @@ tests = testGroup "All Tests"
                                 , ("appTupleBad", "smtAppTupleBad")
                                 , ("pairABad", "smtPairA")
                                 , ("myZipBad", "smtMyZip")
+
+                                -- Regex
+                                , ("isNum", "smtIsNum")
                                 ]
         , checkNebulaPackage "tests/RewriteVerify/PluginTests/Simple" ["add_assoc", "fg", "fg_toint"] ["f_one"]]
 

--- a/tests_plugin/Main.hs
+++ b/tests_plugin/Main.hs
@@ -18,8 +18,9 @@ tests :: TestTree
 tests = testGroup "All Tests"
         [ checkG2Package "tests/G2Plugin/Simple" ["f", "g", "recCall"]
         , checkG2PackageEquiv "tests/G2Plugin/Strings"
-                                [ 
-                                  -- Strings  
+                                -- Equivalent functions
+                                [
+                                  -- Strings
                                   ("f", "f2")
                                 , ("myApp", "app")
                                 , ("appMult", "smtAppMult")
@@ -40,9 +41,15 @@ tests = testGroup "All Tests"
                                 , ("pairA", "smtPairA")
                                 , ("myZip", "smtMyZip")
                                 , ("myA", "smtMyA")
+
+                                -- Regex
+                                , ("isNum", "smtIsNum")
+                                , ("containsFour", "smtContainsFour")
+                                , ("noPat", "smtNoPat")
                                 ]
-                                [ 
-                                  -- Strings  
+                                -- Non-equivalent functions
+                                [
+                                  -- Strings
                                   ("corr", "smtCorr")
                                 , ("incorr", "smtIncorr")
                                 , ("addTwoAll", "smtAddTwoAll")
@@ -51,14 +58,16 @@ tests = testGroup "All Tests"
                                 , ("myIntersperseBeginBad", "smtMyIntersperseBeginBad")
                                 , ("myRevBad", "smtMyRevBad")
                                 , ("myRevApp1Bad", "smtMyRevApp1Bad")
-                                
+
                                 -- Tuples
                                 , ("appTupleBad", "smtAppTupleBad")
                                 , ("pairABad", "smtPairA")
                                 , ("myZipBad", "smtMyZip")
 
                                 -- Regex
-                                , ("isNum", "smtIsNum")
+                                , ("isNumBad", "smtIsNumBad")
+                                , ("containsFourBad", "smtContainsFourBad")
+                                , ("noPatBad", "smtNoPatBad")
                                 ]
         , checkNebulaPackage "tests/RewriteVerify/PluginTests/Simple" ["add_assoc", "fg", "fg_toint"] ["f_one"]]
 
@@ -106,9 +115,9 @@ ranFuncEquiv io_out =
                 (f1 ++ " and " ++ f2)
                 (do
                     out <- io_out
-                    assertBool (if checkInequiv f1 f2 out
-                                    then "Found inequivalent " ++ f1 ++ " and " ++ f2
-                                    else "Not run " ++ f1 ++ " and " ++ f2)
+                    assertBool ((if checkInequiv f1 f2 out
+                                     then "Found inequivalent " ++ f1 ++ " and " ++ f2
+                                     else "Not run " ++ f1 ++ " and " ++ f2) ++ "\nFull output:\n" ++ out)
                                (checkEquiv f1 f2 out))
         )
 
@@ -119,8 +128,8 @@ ranFuncInequiv io_out =
                 (do
                     out <- io_out
                     assertBool ((if checkEquiv f1 f2 out
-                                    then "Found equivalent " ++ f1 ++ " and " ++ f2
-                                    else "Not run " ++ f1 ++ " and " ++ f2) ++ "\n" ++ out)
+                                     then "Found equivalent " ++ f1 ++ " and " ++ f2
+                                     else "Not run " ++ f1 ++ " and " ++ f2) ++ "\nFull output:\n" ++ out)
                                (checkInequiv f1 f2 out))
         )
 

--- a/verify/tests/Definitions.hs
+++ b/verify/tests/Definitions.hs
@@ -1,4 +1,8 @@
 {-# LANGUAGE DeriveDataTypeable, FlexibleInstances #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 {-
 
     Definitions for the properties in Productive Use Of Failure

--- a/verify/tests/Nat.hs
+++ b/verify/tests/Nat.hs
@@ -1,3 +1,6 @@
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+
 module Nat where
 
 import Prelude hiding ((+),(*),(-),(<),id)

--- a/verify/tests/Zeno.hs
+++ b/verify/tests/Zeno.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module Zeno where
 

--- a/verify/tests/ZenoBadProp.hs
+++ b/verify/tests/ZenoBadProp.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module ZenoBadProp where
 

--- a/verify/tests/ZenoWithDelete.hs
+++ b/verify/tests/ZenoWithDelete.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module ZenoWithDelete where
 

--- a/verify/tests/ZenoWithDrop.hs
+++ b/verify/tests/ZenoWithDrop.hs
@@ -1,4 +1,8 @@
 {-# LANGUAGE BangPatterns #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 
 module ZenoWithDrop where
 

--- a/verify/tests/ZenoWithElem.hs
+++ b/verify/tests/ZenoWithElem.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module ZenoWithElem where
 

--- a/verify/tests/ZenoWithFilter.hs
+++ b/verify/tests/ZenoWithFilter.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module ZenoWithFilter where
 

--- a/verify/tests/ZenoWithHeight.hs
+++ b/verify/tests/ZenoWithHeight.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module ZenoWithHeight where
 

--- a/verify/tests/ZenoWithIns.hs
+++ b/verify/tests/ZenoWithIns.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module ZenoWithIns where
 

--- a/verify/tests/ZenoWithLen.hs
+++ b/verify/tests/ZenoWithLen.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module ZenoWithLen where
 

--- a/verify/tests/ZenoWithMap.hs
+++ b/verify/tests/ZenoWithMap.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module ZenoWithMap where
 

--- a/verify/tests/ZenoWithMirror.hs
+++ b/verify/tests/ZenoWithMirror.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module ZenoWithMirror where
 

--- a/verify/tests/ZenoWithRev.hs
+++ b/verify/tests/ZenoWithRev.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module ZenoWithRev where
 

--- a/verify/tests/ZenoWithTake.hs
+++ b/verify/tests/ZenoWithTake.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module ZenoWithTake where
 

--- a/verify/tests/ZenoWithTakeWhile.hs
+++ b/verify/tests/ZenoWithTakeWhile.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module ZenoWithTakeWhile where
 

--- a/verify/tests/ZenoWithZip.hs
+++ b/verify/tests/ZenoWithZip.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module ZenoWithZip where
 
@@ -66,30 +69,37 @@ _    && _    = False
 
 -- Natural numbers
 
+(===) :: Nat -> Nat -> Bool
 Z     === Z     = True
 Z     === _     = False
 (S _) === Z     = False
 (S x) === (S y) = x === y
 
+(<=) :: Nat -> Nat -> Bool
 Z     <= _     = True
 _     <= Z     = False
 (S x) <= (S y) = x <= y
 
+(<) :: Nat -> Nat -> Bool
 _     < Z     = False
 Z     < _     = True
 (S x) < (S y) = x < y
 
+(+) :: Nat -> Nat -> Nat
 Z     + y = y
 (S x) + y = S (x + y)
 
+(-) :: Nat -> Nat -> Nat
 Z     - _     = Z
 x     - Z     = x
 (S x) - (S y) = x - y
 
-min Z     y     = Z
-min (S x) Z     = Z
+min :: Nat -> Nat -> Nat
+min Z     _     = Z
+min (S _) Z     = Z
 min (S x) (S y) = S (min x y)
 
+max :: Nat -> Nat -> Nat
 max Z     y     = y
 max x     Z     = x
 max (S x) (S y) = S (max x y)
@@ -109,9 +119,10 @@ rev [] = []
 rev (x:xs) = rev xs ++ [x]
 
 -- BUG
+zip :: [a] -> [b] -> [(a, b)]
 zip [] _ = []
 zip _ [] = []
-zip (x:x':xs) (y:y':ys) = (x, y) : (zip xs ys)
+zip (x:_:xs) (y:_:ys) = (x, y) : (zip xs ys)
 zip (x:xs) (y:ys) = (x, y) : (zip xs ys)
 
 delete :: Nat -> [Nat] -> [Nat]
@@ -132,23 +143,25 @@ elem n (x:xs) =
     True -> True
     False -> elem n xs
 
+drop :: Nat -> [a] -> [a]
 drop Z xs = xs
 drop _ [] = []
 drop (S x) (_:xs) = drop x xs
 
+take :: Nat -> [a] -> [a]
 take Z _ = []
 take _ [] = []
 take (S x) (y:ys) = y : (take x ys)
 
 count :: Nat -> [Nat] -> Nat
-count x [] = Z
+count _ [] = Z
 count x (y:ys) =
   case x === y of
     True -> S (count x ys)
     _ -> count x ys
 
 map :: (a -> b) -> [a] -> [b]
-map f [] = []
+map _ [] = []
 map f (x:xs) = (f x) : (map f xs)
 
 takeWhile :: (a -> Bool) -> [a] -> [a]
@@ -174,17 +187,17 @@ filter p (x:xs) =
 
 butlast :: [a] -> [a]
 butlast [] = []
-butlast [x] = []
+butlast [_] = []
 butlast (x:xs) = x:(butlast xs)
 
 last :: [Nat] -> Nat
 last [] = Z
 last [x] = x
-last (x:xs) = last xs
+last (_:xs) = last xs
 
 sorted :: [Nat] -> Bool
 sorted [] = True
-sorted [x] = True
+sorted [_] = True
 sorted (x:y:ys) = (x <= y) && sorted (y:ys)
 
 insort :: Nat -> [Nat] -> [Nat]
@@ -226,7 +239,7 @@ zipConcat x xs (y:ys) = (x, y) : zip xs ys
 
 height :: Tree a -> Nat
 height Leaf = Z
-height (Node l x r) = S (max (height l) (height r))
+height (Node l _ r) = S (max (height l) (height r))
 
 mirror :: Tree a -> Tree a
 mirror Leaf = Leaf

--- a/verify/tests/ZenoWithZip.hs
+++ b/verify/tests/ZenoWithZip.hs
@@ -69,37 +69,30 @@ _    && _    = False
 
 -- Natural numbers
 
-(===) :: Nat -> Nat -> Bool
 Z     === Z     = True
 Z     === _     = False
 (S _) === Z     = False
 (S x) === (S y) = x === y
 
-(<=) :: Nat -> Nat -> Bool
 Z     <= _     = True
 _     <= Z     = False
 (S x) <= (S y) = x <= y
 
-(<) :: Nat -> Nat -> Bool
 _     < Z     = False
 Z     < _     = True
 (S x) < (S y) = x < y
 
-(+) :: Nat -> Nat -> Nat
 Z     + y = y
 (S x) + y = S (x + y)
 
-(-) :: Nat -> Nat -> Nat
 Z     - _     = Z
 x     - Z     = x
 (S x) - (S y) = x - y
 
-min :: Nat -> Nat -> Nat
-min Z     _     = Z
-min (S _) Z     = Z
+min Z     y     = Z
+min (S x) Z     = Z
 min (S x) (S y) = S (min x y)
 
-max :: Nat -> Nat -> Nat
 max Z     y     = y
 max x     Z     = x
 max (S x) (S y) = S (max x y)
@@ -119,10 +112,9 @@ rev [] = []
 rev (x:xs) = rev xs ++ [x]
 
 -- BUG
-zip :: [a] -> [b] -> [(a, b)]
 zip [] _ = []
 zip _ [] = []
-zip (x:_:xs) (y:_:ys) = (x, y) : (zip xs ys)
+zip (x:x':xs) (y:y':ys) = (x, y) : (zip xs ys)
 zip (x:xs) (y:ys) = (x, y) : (zip xs ys)
 
 delete :: Nat -> [Nat] -> [Nat]
@@ -143,25 +135,23 @@ elem n (x:xs) =
     True -> True
     False -> elem n xs
 
-drop :: Nat -> [a] -> [a]
 drop Z xs = xs
 drop _ [] = []
 drop (S x) (_:xs) = drop x xs
 
-take :: Nat -> [a] -> [a]
 take Z _ = []
 take _ [] = []
 take (S x) (y:ys) = y : (take x ys)
 
 count :: Nat -> [Nat] -> Nat
-count _ [] = Z
+count x [] = Z
 count x (y:ys) =
   case x === y of
     True -> S (count x ys)
     _ -> count x ys
 
 map :: (a -> b) -> [a] -> [b]
-map _ [] = []
+map f [] = []
 map f (x:xs) = (f x) : (map f xs)
 
 takeWhile :: (a -> Bool) -> [a] -> [a]
@@ -187,17 +177,17 @@ filter p (x:xs) =
 
 butlast :: [a] -> [a]
 butlast [] = []
-butlast [_] = []
+butlast [x] = []
 butlast (x:xs) = x:(butlast xs)
 
 last :: [Nat] -> Nat
 last [] = Z
 last [x] = x
-last (_:xs) = last xs
+last (x:xs) = last xs
 
 sorted :: [Nat] -> Bool
 sorted [] = True
-sorted [_] = True
+sorted [x] = True
 sorted (x:y:ys) = (x <= y) && sorted (y:ys)
 
 insort :: Nat -> [Nat] -> [Nat]
@@ -239,7 +229,7 @@ zipConcat x xs (y:ys) = (x, y) : zip xs ys
 
 height :: Tree a -> Nat
 height Leaf = Z
-height (Node l _ r) = S (max (height l) (height r))
+height (Node l x r) = S (max (height l) (height r))
 
 mirror :: Tree a -> Tree a
 mirror Leaf = Leaf


### PR DESCRIPTION
- Added regex primitive functions to plugin
- Fairly simple tests (maybe more in the future, some more complicated tests were causing timeouts in cvc5)
- z3 chokes on most regex formulas so all tests are with cvc5
- Suppressed some warnings in test files so it's easier to find test results during `cabal run test-plugin`